### PR TITLE
Events within visit

### DIFF
--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -541,6 +541,12 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
 
       clauses.add(String.format("A.END_DATE >= %s AND A.END_DATE <= %s", startExpression, endExpression));    
     }
+	
+	// RestrictVisit
+	boolean restrictVisit = corelatedCriteria.restrictVisit;
+	if (restrictVisit)
+	  clauses.add("A.visit_occurrence_id = P.visit_occurrence_id");
+  
     query = StringUtils.replace(query,"@windowCriteria",StringUtils.join(clauses, " AND "));
 
     // Occurrence criteria

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CorelatedCriteria.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CorelatedCriteria.java
@@ -35,5 +35,8 @@ public class CorelatedCriteria {
   public Window endWindow;  
   
   @JsonProperty("Occurrence")
-  public Occurrence occurrence;  
+  public Occurrence occurrence;
+  
+  @JsonProperty("restrictVisit")
+  public boolean restrictVisit = false;
 }

--- a/src/main/resources/resources/cohortdefinition/sql/conditionEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionEra.sql
@@ -1,5 +1,5 @@
 -- Begin Condition Era Criteria
-select C.person_id, C.condition_era_id as event_id, C.condition_era_start_date as start_date, C.condition_era_end_date as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
+select C.person_id, C.condition_era_id as event_id, C.condition_era_start_date as start_date, C.condition_era_end_date as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
   select ce.*, ROW_NUMBER() over (PARTITION BY ce.person_id ORDER BY ce.condition_era_start_date, ce.condition_era_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
@@ -1,5 +1,5 @@
 -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id
 FROM 
 (
   SELECT co.*, ROW_NUMBER() over (PARTITION BY co.person_id ORDER BY co.condition_start_date, co.condition_occurrence_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/death.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/death.sql
@@ -1,5 +1,5 @@
 -- Begin Death Criteria
-select C.person_id, C.person_id as event_id, C.death_date as start_date, DATEADD(d,1,C.death_date) as end_date, coalesce(C.cause_concept_id,0) as TARGET_CONCEPT_ID
+select C.person_id, C.person_id as event_id, C.death_date as start_date, DATEADD(d,1,C.death_date) as end_date, coalesce(C.cause_concept_id,0) as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
   select d.*

--- a/src/main/resources/resources/cohortdefinition/sql/deviceExposure.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/deviceExposure.sql
@@ -1,5 +1,5 @@
 -- Begin Device Exposure Criteria
-select C.person_id, C.device_exposure_id as event_id, C.device_exposure_start_date as start_date, C.device_exposure_end_date as end_date, C.device_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.device_exposure_id as event_id, C.device_exposure_start_date as start_date, C.device_exposure_end_date as end_date, C.device_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.device_exposure_start_date, de.device_exposure_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/doseEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/doseEra.sql
@@ -1,5 +1,5 @@
 -- Begin Dose Era Criteria
-select C.person_id, C.dose_era_id as event_id, C.dose_era_start_date as start_date, C.dose_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.dose_era_id as event_id, C.dose_era_start_date as start_date, C.dose_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.dose_era_start_date, de.dose_era_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/drugEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/drugEra.sql
@@ -1,5 +1,5 @@
 -- Begin Drug Era Criteria
-select C.person_id, C.drug_era_id as event_id, C.drug_era_start_date as start_date, C.drug_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.drug_era_id as event_id, C.drug_era_start_date as start_date, C.drug_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.drug_era_start_date, de.drug_era_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/drugExposure.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/drugExposure.sql
@@ -1,5 +1,5 @@
 -- Begin Drug Exposure Criteria
-select C.person_id, C.drug_exposure_id as event_id, C.drug_exposure_start_date as start_date, COALESCE(C.drug_exposure_end_date, DATEADD(day, 1, C.drug_exposure_start_date)) as end_date, C.drug_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.drug_exposure_id as event_id, C.drug_exposure_start_date as start_date, COALESCE(C.drug_exposure_end_date, DATEADD(day, 1, C.drug_exposure_start_date)) as end_date, C.drug_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
   select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.drug_exposure_start_date, de.drug_exposure_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -1,14 +1,14 @@
 @codesetQuery
 
-with primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date) as
+with primary_events (event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id) as
 (
 @primaryEventsQuery
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
-  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date @QualifiedEventSort) as ordinal
+  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date @QualifiedEventSort) as ordinal, pe.visit_occurrence_id
   FROM primary_events pe
   @additionalCriteriaQuery
 ) QE

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -8,7 +8,7 @@ SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, vi
 INTO #qualified_events
 FROM 
 (
-  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, row_number() over (partition by pe.person_id order by pe.start_date @QualifiedEventSort) as ordinal, pe.visit_occurrence_id
+  select pe.event_id, pe.person_id, pe.start_date, pe.end_date, pe.op_start_date, pe.op_end_date, dense_rank() over (partition by pe.person_id order by pe.start_date @QualifiedEventSort) as ordinal, pe.visit_occurrence_id
   FROM primary_events pe
   @additionalCriteriaQuery
 ) QE

--- a/src/main/resources/resources/cohortdefinition/sql/measurement.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/measurement.sql
@@ -1,5 +1,5 @@
 -- Begin Measurement Criteria
-select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE, C.measurement_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE, C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
   select m.*, ROW_NUMBER() over (PARTITION BY m.person_id ORDER BY m.measurement_date, m.measurement_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/observation.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/observation.sql
@@ -1,5 +1,5 @@
 -- Begin Observation Criteria
-select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE, C.observation_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE, C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
   select o.*, ROW_NUMBER() over (PARTITION BY o.person_id ORDER BY o.observation_date, o.observation_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/observationPeriod.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/observationPeriod.sql
@@ -1,5 +1,5 @@
 -- Begin Observation Period Criteria
-select C.person_id, C.observation_period_id as event_id, @startDateExpression as start_date, @endDateExpression as end_date, C.period_type_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.observation_period_id as event_id, @startDateExpression as start_date, @endDateExpression as end_date, C.period_type_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
         select op.*, ROW_NUMBER() over (PARTITION BY op.person_id ORDER BY op.observation_period_start_date) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
@@ -1,8 +1,8 @@
 -- Begin Primary Events
-select row_number() over (PARTITION BY P.person_id order by P.start_date) as event_id, P.person_id, P.start_date, P.end_date, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date
+select row_number() over (PARTITION BY P.person_id order by P.start_date) as event_id, P.person_id, P.start_date, P.end_date, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, P.visit_occurrence_id
 FROM
 (
-  select P.person_id, P.start_date, P.end_date, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date @EventSort) ordinal
+  select P.person_id, P.start_date, P.end_date, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date @EventSort) ordinal, P.visit_id
   FROM 
   (
   @criteriaQueries

--- a/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
@@ -2,7 +2,7 @@
 select row_number() over (PARTITION BY P.person_id order by P.start_date) as event_id, P.person_id, P.start_date, P.end_date, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, P.visit_occurrence_id
 FROM
 (
-  select P.person_id, P.start_date, P.end_date, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date @EventSort) ordinal, P.visit_id
+  select P.person_id, P.start_date, P.end_date, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date @EventSort) ordinal, P.visit_occurrence_id
   FROM 
   (
   @criteriaQueries

--- a/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
@@ -1,5 +1,5 @@
 -- Begin Procedure Occurrence Criteria
-select C.person_id, C.procedure_occurrence_id as event_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE, C.procedure_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.procedure_occurrence_id as event_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE, C.procedure_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
   select po.*, ROW_NUMBER() over (PARTITION BY po.person_id ORDER BY po.procedure_date, po.procedure_occurrence_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/specimen.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/specimen.sql
@@ -1,5 +1,5 @@
 -- Begin Specimen Criteria
-select C.person_id, C.specimen_id as event_id, C.specimen_date as start_date, DATEADD(d,1,C.specimen_date) as end_date, C.specimen_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.specimen_id as event_id, C.specimen_date as start_date, DATEADD(d,1,C.specimen_date) as end_date, C.specimen_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
   select s.*, ROW_NUMBER() over (PARTITION BY s.person_id ORDER BY s.specimen_date, s.specimen_id) as ordinal

--- a/src/main/resources/resources/cohortdefinition/sql/visitOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/visitOccurrence.sql
@@ -1,5 +1,5 @@
 -- Begin Visit Occurrence Criteria
-select C.person_id, C.visit_occurrence_id as event_id, C.visit_start_date as start_date, C.visit_end_date as end_date, C.visit_concept_id as TARGET_CONCEPT_ID
+select C.person_id, C.visit_occurrence_id as event_id, C.visit_start_date as start_date, C.visit_end_date as end_date, C.visit_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
   select vo.*, ROW_NUMBER() over (PARTITION BY vo.person_id ORDER BY vo.visit_start_date, vo.visit_occurrence_id) as ordinal


### PR DESCRIPTION
This pull-request addresses the following:

1. New major functionality in creating Qualified_events. Option to restrict events within same visit
2. visit_occurrence is maybe used to generate statistics about cohort-creation
3. changed row_number() to dense_rank() to allow to restrict to earliest-event, latest-event or all-event in qualified-event queries.
https://github.com/OHDSI/Atlas/issues/454