### PR TITLE
row_number() to dense_rank()

### DIFF
--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CorelatedCriteria.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CorelatedCriteria.java
@@ -37,6 +37,6 @@ public class CorelatedCriteria {
   @JsonProperty("Occurrence")
   public Occurrence occurrence;
   
-  @JsonProperty("restrictVisit")
+  @JsonProperty("RestrictVisit")
   public boolean restrictVisit = false;
 }

--- a/src/main/resources/resources/cohortdefinition/sql/conditionEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionEra.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.condition_era_id as event_id, C.condition_era_start_date as start_date, C.condition_era_end_date as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
-  select ce.*, ROW_NUMBER() over (PARTITION BY ce.person_id ORDER BY ce.condition_era_start_date, ce.condition_era_id) as ordinal
+  select ce.*, dense_rank() over (PARTITION BY ce.person_id ORDER BY ce.condition_era_start_date, ce.condition_era_id) as ordinal
   FROM @cdm_database_schema.CONDITION_ERA ce
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/conditionOccurrence.sql
@@ -2,7 +2,7 @@
 SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date, C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id
 FROM 
 (
-  SELECT co.*, ROW_NUMBER() over (PARTITION BY co.person_id ORDER BY co.condition_start_date, co.condition_occurrence_id) as ordinal
+  SELECT co.*, dense_rank() over (PARTITION BY co.person_id ORDER BY co.condition_start_date, co.condition_occurrence_id) as ordinal
   FROM @cdm_database_schema.CONDITION_OCCURRENCE co
   @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/deviceExposure.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/deviceExposure.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.device_exposure_id as event_id, C.device_exposure_start_date as start_date, C.device_exposure_end_date as end_date, C.device_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
-  select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.device_exposure_start_date, de.device_exposure_id) as ordinal
+  select de.*, dense_rank() over (PARTITION BY de.person_id ORDER BY de.device_exposure_start_date, de.device_exposure_id) as ordinal
   FROM @cdm_database_schema.DEVICE_EXPOSURE de
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/doseEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/doseEra.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.dose_era_id as event_id, C.dose_era_start_date as start_date, C.dose_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
-  select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.dose_era_start_date, de.dose_era_id) as ordinal
+  select de.*, dense_rank() over (PARTITION BY de.person_id ORDER BY de.dose_era_start_date, de.dose_era_id) as ordinal
   FROM @cdm_database_schema.DOSE_ERA de
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/drugEra.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/drugEra.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.drug_era_id as event_id, C.drug_era_start_date as start_date, C.drug_era_end_date as end_date, C.drug_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
-  select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.drug_era_start_date, de.drug_era_id) as ordinal
+  select de.*, dense_rank() over (PARTITION BY de.person_id ORDER BY de.drug_era_start_date, de.drug_era_id) as ordinal
   FROM @cdm_database_schema.DRUG_ERA de
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/drugExposure.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/drugExposure.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.drug_exposure_id as event_id, C.drug_exposure_start_date as start_date, COALESCE(C.drug_exposure_end_date, DATEADD(day, 1, C.drug_exposure_start_date)) as end_date, C.drug_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
-  select de.*, ROW_NUMBER() over (PARTITION BY de.person_id ORDER BY de.drug_exposure_start_date, de.drug_exposure_id) as ordinal
+  select de.*, dense_rank() over (PARTITION BY de.person_id ORDER BY de.drug_exposure_start_date, de.drug_exposure_id) as ordinal
   FROM @cdm_database_schema.DRUG_EXPOSURE de
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -27,7 +27,7 @@ create table #inclusionRuleCohorts
 
 with cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal) as
 (
-  SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, row_number() over (partition by person_id order by start_date @IncludedEventSort) as ordinal
+  SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, dense_rank() over (partition by person_id order by start_date @IncludedEventSort) as ordinal
   from
   (
     select Q.event_id, Q.person_id, Q.start_date, Q.end_date, Q.op_start_date, Q.op_end_date, SUM(coalesce(POWER(cast(2 as bigint), I.inclusion_rule_id), 0)) as inclusion_rule_mask
@@ -62,7 +62,7 @@ with collapse_constructor_input (person_id, start_date, end_date) as
 (
 	select F.person_id, F.start_date, F.end_date
 	FROM (
-	  select I.event_id, I.person_id, I.start_date, E.end_date, row_number() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
+	  select I.event_id, I.person_id, I.start_date, E.end_date, dense_rank() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
 	  from #included_events I
 	  join #cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
 	) F

--- a/src/main/resources/resources/cohortdefinition/sql/measurement.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/measurement.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.measurement_id as event_id, C.measurement_date as start_date, DATEADD(d,1,C.measurement_date) as END_DATE, C.measurement_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
-  select m.*, ROW_NUMBER() over (PARTITION BY m.person_id ORDER BY m.measurement_date, m.measurement_id) as ordinal
+  select m.*, dense_rank() over (PARTITION BY m.person_id ORDER BY m.measurement_date, m.measurement_id) as ordinal
   FROM @cdm_database_schema.MEASUREMENT m
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/observation.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/observation.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.observation_id as event_id, C.observation_date as start_date, DATEADD(d,1,C.observation_date) as END_DATE, C.observation_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
-  select o.*, ROW_NUMBER() over (PARTITION BY o.person_id ORDER BY o.observation_date, o.observation_id) as ordinal
+  select o.*, dense_rank() over (PARTITION BY o.person_id ORDER BY o.observation_date, o.observation_id) as ordinal
   FROM @cdm_database_schema.OBSERVATION o
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/observationPeriod.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/observationPeriod.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.observation_period_id as event_id, @startDateExpression as start_date, @endDateExpression as end_date, C.period_type_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
-        select op.*, ROW_NUMBER() over (PARTITION BY op.person_id ORDER BY op.observation_period_start_date) as ordinal
+        select op.*, dense_rank() over (PARTITION BY op.person_id ORDER BY op.observation_period_start_date) as ordinal
         FROM @cdm_database_schema.OBSERVATION_PERIOD op
 ) C
 @joinClause

--- a/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/primaryEventsQuery.sql
@@ -2,7 +2,7 @@
 select row_number() over (PARTITION BY P.person_id order by P.start_date) as event_id, P.person_id, P.start_date, P.end_date, OP.observation_period_start_date as op_start_date, OP.observation_period_end_date as op_end_date, P.visit_occurrence_id
 FROM
 (
-  select P.person_id, P.start_date, P.end_date, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date @EventSort) ordinal, P.visit_occurrence_id
+  select P.person_id, P.start_date, P.end_date, dense_rank() OVER (PARTITION BY person_id ORDER BY start_date @EventSort) ordinal, P.visit_occurrence_id
   FROM 
   (
   @criteriaQueries

--- a/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/procedureOccurrence.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.procedure_occurrence_id as event_id, C.procedure_date as start_date, DATEADD(d,1,C.procedure_date) as END_DATE, C.procedure_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
-  select po.*, ROW_NUMBER() over (PARTITION BY po.person_id ORDER BY po.procedure_date, po.procedure_occurrence_id) as ordinal
+  select po.*, dense_rank() over (PARTITION BY po.person_id ORDER BY po.procedure_date, po.procedure_occurrence_id) as ordinal
   FROM @cdm_database_schema.PROCEDURE_OCCURRENCE po
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/specimen.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/specimen.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.specimen_id as event_id, C.specimen_date as start_date, DATEADD(d,1,C.specimen_date) as end_date, C.specimen_concept_id as TARGET_CONCEPT_ID, NULL as visit_occurrence_id
 from 
 (
-  select s.*, ROW_NUMBER() over (PARTITION BY s.person_id ORDER BY s.specimen_date, s.specimen_id) as ordinal
+  select s.*, dense_rank() over (PARTITION BY s.person_id ORDER BY s.specimen_date, s.specimen_id) as ordinal
   FROM @cdm_database_schema.SPECIMEN s
 @codesetClause
 ) C

--- a/src/main/resources/resources/cohortdefinition/sql/visitOccurrence.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/visitOccurrence.sql
@@ -2,7 +2,7 @@
 select C.person_id, C.visit_occurrence_id as event_id, C.visit_start_date as start_date, C.visit_end_date as end_date, C.visit_concept_id as TARGET_CONCEPT_ID, C.visit_occurrence_id
 from 
 (
-  select vo.*, ROW_NUMBER() over (PARTITION BY vo.person_id ORDER BY vo.visit_start_date, vo.visit_occurrence_id) as ordinal
+  select vo.*, dense_rank() over (PARTITION BY vo.person_id ORDER BY vo.visit_start_date, vo.visit_occurrence_id) as ordinal
   FROM @cdm_database_schema.VISIT_OCCURRENCE vo
 @codesetClause
 ) C


### PR DESCRIPTION
Changed row_number() to dense_rank() everywhere ordinal was created for use in restriction to earliest_event or latest_event.