### PR TITLE
Issue 14 optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.ohdsi</groupId>
     <artifactId>circe</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.0</version>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpression.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpression.java
@@ -20,6 +20,7 @@ package org.ohdsi.circe.cohortdefinition;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +31,8 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown=true)
 public class CohortExpression {
-  
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
   @JsonProperty("Title")  
   public String title;
   
@@ -60,4 +62,13 @@ public class CohortExpression {
   
   @JsonProperty("CollapseSettings")
   public CollapseSettings collapseSettings = new CollapseSettings();
+	
+	public static CohortExpression fromJson(String json) {
+		try {
+			CohortExpression expression = JSON_MAPPER.readValue(json, CohortExpression.class);
+			return expression;
+		} catch (Exception e) {
+			throw new RuntimeException("Error parsing cohort expression", e);
+		}
+	}
 }

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -20,6 +20,7 @@ package org.ohdsi.circe.cohortdefinition;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.ohdsi.circe.helper.ResourceHelper;
 import org.ohdsi.circe.vocabulary.Concept;
@@ -237,9 +238,6 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
  
   private String getCensoringEventsQuery(Criteria[] censoringCriteria)
   {
-    if (censoringCriteria == null || censoringCriteria.length == 0)
-      return "";
-    
     ArrayList<String> criteriaQueries = new ArrayList<>();
     for (Criteria c : censoringCriteria)    
     {
@@ -247,7 +245,7 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
       criteriaQueries.add(StringUtils.replace(CENSORING_QUERY_TEMPLATE, "@criteriaQuery", criteriaQuery));
     }
     
-    return StringUtils.join(criteriaQueries,"\n");
+    return StringUtils.join(criteriaQueries,"\nUNION ALL\n");
   }
   
   public String getPrimaryEventsQuery(PrimaryCriteria primaryCriteria) {
@@ -319,17 +317,35 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     else
       resultSql = StringUtils.replace(resultSql, "@QualifiedLimitFilter","");    
     
-    ArrayList<String> inclusionRuleInserts = new ArrayList<>();
-    for (int i = 0; i < expression.inclusionRules.size(); i++)
-    {
-      CriteriaGroup cg = expression.inclusionRules.get(i).expression;
-      String inclusionRuleInsert = getInclusionRuleQuery(cg);
-      inclusionRuleInsert = StringUtils.replace(inclusionRuleInsert, "@inclusion_rule_id", "" +  i);
-      inclusionRuleInserts.add(inclusionRuleInsert);
-    }
-    
-    resultSql = StringUtils.replace(resultSql,"@inclusionCohortInserts", StringUtils.join(inclusionRuleInserts,"\n"));
+    if (expression.inclusionRules.size() > 0) {
+			ArrayList<String> inclusionRuleInserts = new ArrayList<>();
+			ArrayList<String> inclusionRuleTempTables = new ArrayList<>();
 
+			for (int i = 0; i < expression.inclusionRules.size(); i++)
+			{
+				CriteriaGroup cg = expression.inclusionRules.get(i).expression;
+				String inclusionRuleInsert = getInclusionRuleQuery(cg);
+				inclusionRuleInsert = StringUtils.replace(inclusionRuleInsert, "@inclusion_rule_id", "" +  i);
+				inclusionRuleInserts.add(inclusionRuleInsert);
+				inclusionRuleTempTables.add(String.format("#InclusionRuleCohort_%d", i));
+			}
+			
+			String irTempUnion = inclusionRuleTempTables.stream()
+				.map(d -> String.format("select inclusion_rule_id, person_id, event_id from %s", d))
+				.collect(Collectors.joining("\nUNION ALL\n"));
+			
+			inclusionRuleInserts.add(String.format("SELECT inclusion_rule_id, person_id, event_id\nINTO #inclusionRuleCohorts\nFROM (%s) I;",irTempUnion));
+			
+			inclusionRuleInserts.addAll(inclusionRuleTempTables.stream()
+				.map(d-> String.format("TRUNCATE TABLE %s;\nDROP TABLE %s;\n", d, d))
+				.collect(Collectors.toList())
+			);
+			
+			resultSql = StringUtils.replace(resultSql,"@inclusionCohortInserts", StringUtils.join(inclusionRuleInserts,"\n"));
+		} else {
+			resultSql = StringUtils.replace(resultSql,"@inclusionCohortInserts", "create table #inclusionRuleCohorts (inclusion_rule_id bigint,\n\tperson_id bigint,\n\tevent_id bigint\n)");
+		}
+    
     resultSql = StringUtils.replace(resultSql, "@IncludedEventSort", (expression.expressionLimit.type != null && expression.expressionLimit.type.equalsIgnoreCase("LAST")) ? "DESC" : "ASC");
 
     if (expression.expressionLimit.type != null && !expression.expressionLimit.type.equalsIgnoreCase("ALL"))
@@ -341,18 +357,30 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     
     resultSql = StringUtils.replace(resultSql, "@ruleTotal", String.valueOf(expression.inclusionRules.size()));
 
-    if (expression.endStrategy != null)
-      resultSql = StringUtils.replace(resultSql, "@strategyInserts", expression.endStrategy.accept(this, "#included_events"));
-    else
-      resultSql = StringUtils.replace(resultSql, "@strategyInserts", "");
-    
-      
-    resultSql = StringUtils.replace(resultSql, "@censoringInserts", getCensoringEventsQuery(expression.censoringCriteria));
-    
-    resultSql = StringUtils.replace(resultSql, "@collapseConstructor", getCollapseConstructorQuery(expression.collapseSettings));
+		ArrayList<String> endDateSelects = new ArrayList<>();
 	
-	// table from which to records are read and inserted into the db
-    resultSql = StringUtils.replace(resultSql, "@output_table", "#collapse_output");
+		if (!(expression.endStrategy instanceof DateOffsetStrategy)) {
+			endDateSelects.add("-- By default, cohort exit at the event's op end date\nselect event_id, person_id, op_end_date as end_date from #included_events");
+		}
+		
+		if (expression.endStrategy != null) {
+			// replace @strategy_ends placeholders with temp table creation and cleanup scripts.
+			resultSql = StringUtils.replace(resultSql,"@strategy_ends_temp_tables",expression.endStrategy.accept(this, "#included_events"));
+			resultSql = StringUtils.replace(resultSql,"@strategy_ends_cleanup", "TRUNCATE TABLE #strategy_ends;\nDROP TABLE #strategy_ends;\n");
+			endDateSelects.add(String.format("-- End Date Strategy\n%s\n","SELECT event_id, person_id, end_date from #strategy_ends"));
+		} else {
+			// replace @trategy_ends placeholders with empty string
+			resultSql = StringUtils.replace(resultSql,"@strategy_ends_temp_tables","");
+			resultSql = StringUtils.replace(resultSql,"@strategy_ends_cleanup","");
+		}
+	
+    
+		if (expression.censoringCriteria != null && expression.censoringCriteria.length > 0)
+			endDateSelects.add(String.format("-- Censor Events\n%s\n",getCensoringEventsQuery(expression.censoringCriteria)));
+
+		resultSql = StringUtils.replace(resultSql, "@cohort_end_unions", StringUtils.join(endDateSelects,"\nUNION ALL\n"));
+		
+		resultSql = StringUtils.replace(resultSql, "@eraconstructorpad", Integer.toString(expression.collapseSettings.eraPad));
 	
     if (options != null)
     {
@@ -543,10 +571,11 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     }
 	
 	// RestrictVisit
-	boolean restrictVisit = corelatedCriteria.restrictVisit;
-	if (restrictVisit)
-	  clauses.add("A.visit_occurrence_id = P.visit_occurrence_id");
-  
+		boolean restrictVisit = corelatedCriteria.restrictVisit;
+		if (restrictVisit) {
+			clauses.add("A.visit_occurrence_id = P.visit_occurrence_id");
+		}
+		
     query = StringUtils.replace(query,"@windowCriteria",StringUtils.join(clauses, " AND "));
 
     // Occurrence criteria
@@ -1882,14 +1911,11 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
   @Override
   public String getStrategySql(DateOffsetStrategy strat, String eventTable) 
   {
-    String insertSql = "-- Date Offset Strategy\nINSERT INTO #cohort_ends (event_id,  person_id, end_date)\n@dateOffsetStrategySql;";
-    
-    String strategySql = StringUtils.replace(DATE_OFFSET_STRATEGY_TEMPLATE, "@eventTable",eventTable);
-    strategySql = StringUtils.replace(strategySql, "@offset",Integer.toString(strat.offset));
-    strategySql = StringUtils.replace(strategySql, "@dateField",getDateFieldForOffsetStrategy(strat.dateField));
-   
-    insertSql = StringUtils.replace(insertSql, "@dateOffsetStrategySql",strategySql);
-    return insertSql;
+    String strategySql = StringUtils.replace(DATE_OFFSET_STRATEGY_TEMPLATE, "@eventTable", eventTable);
+    strategySql = StringUtils.replace(strategySql, "@offset", Integer.toString(strat.offset));
+    strategySql = StringUtils.replace(strategySql, "@dateField", getDateFieldForOffsetStrategy(strat.dateField));
+
+		return strategySql;
   }
 
   @Override
@@ -1898,16 +1924,12 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     if (strat.drugCodesetId == null)
       throw new RuntimeException("Drug Codeset ID can not be NULL.");
     
-    String insertSql = "-- Custom Era Strategy\nINSERT INTO #cohort_ends (event_id,  person_id, end_date)\n@customEraStrategySql;";
-
-    String strategySql = StringUtils.replace(CUSTOM_ERA_STRATEGY_TEMPLATE, "@eventTable",eventTable);
-    strategySql = StringUtils.replace(strategySql, "@drugCodesetId",strat.drugCodesetId.toString());
-    strategySql = StringUtils.replace(strategySql, "@gapDays",Integer.toString(strat.gapDays));
-    strategySql = StringUtils.replace(strategySql, "@offset",Integer.toString(strat.offset));
+    String strategySql = StringUtils.replace(CUSTOM_ERA_STRATEGY_TEMPLATE, "@eventTable", eventTable);
+    strategySql = StringUtils.replace(strategySql, "@drugCodesetId", strat.drugCodesetId.toString());
+    strategySql = StringUtils.replace(strategySql, "@gapDays", Integer.toString(strat.gapDays));
+    strategySql = StringUtils.replace(strategySql, "@offset", Integer.toString(strat.offset));
     
-    insertSql = StringUtils.replace(insertSql, "@customEraStrategySql",strategySql);
-    
-    return insertSql;    
+    return strategySql;    
   }
 
 // </editor-fold>

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -19,6 +19,7 @@
 package org.ohdsi.circe.cohortdefinition;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -69,6 +70,8 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
   private final static String ERA_CONSTRUCTOR_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/cohortdefinition/sql/eraConstructor.sql");
   
   public static class BuildExpressionQueryOptions {
+	  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+		
     @JsonProperty("cohortId")  
     public Integer cohortId;
 
@@ -83,8 +86,20 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     
     @JsonProperty("generateStats")
     public boolean generateStats;
-  }  
-  
+		
+		public static CohortExpressionQueryBuilder.BuildExpressionQueryOptions fromJson(String json)
+		{
+			try {
+				CohortExpressionQueryBuilder.BuildExpressionQueryOptions options = 
+					JSON_MAPPER.readValue(json, CohortExpressionQueryBuilder.BuildExpressionQueryOptions.class);
+				return options;
+			} catch (Exception e) {
+				throw new RuntimeException("Error parsing expression query options", e);
+			}
+		}
+		
+  }
+	
   private ArrayList<Long> getConceptIdsFromConcepts(Concept[] concepts) {
     ArrayList<Long> conceptIdList = new ArrayList<>();
     for (Concept concept : concepts) {

--- a/src/main/java/org/ohdsi/circe/vocabulary/ConceptSetExpression.java
+++ b/src/main/java/org/ohdsi/circe/vocabulary/ConceptSetExpression.java
@@ -18,11 +18,16 @@
  */
 package org.ohdsi.circe.vocabulary;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  *
  * A Class that encapsulates the elements of a Concept Set Expression.
  */
 public class ConceptSetExpression {
+	
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+	
   public static class ConceptSetItem
   {
     public Concept concept;
@@ -33,4 +38,12 @@ public class ConceptSetExpression {
 
   public ConceptSetItem[] items;
   
+	public ConceptSetExpression fromJson(String json) {
+		try {
+			ConceptSetExpression expression = JSON_MAPPER.readValue(json, ConceptSetExpression.class);
+			return expression;
+		} catch (Exception e) {
+			throw new RuntimeException("Error parsing conceptset expression", e);
+		}
+	}
 }

--- a/src/main/resources/resources/cohortdefinition/sql/censoringInsert.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/censoringInsert.sql
@@ -1,4 +1,3 @@
-INSERT INTO #cohort_ends (event_id, person_id, end_date)
 select i.event_id, i.person_id, MIN(c.start_date) as end_date
 FROM #included_events i
 JOIN
@@ -6,4 +5,3 @@ JOIN
 @criteriaQuery
 ) C on C.person_id = I.person_id and C.start_date >= I.start_date and C.START_DATE <= I.op_end_date
 GROUP BY i.event_id, i.person_id
-;

--- a/src/main/resources/resources/cohortdefinition/sql/customEraStrategy.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/customEraStrategy.sql
@@ -1,4 +1,14 @@
+-- custom era strategy
+
+select de.PERSON_ID, DRUG_EXPOSURE_START_DATE,  COALESCE(DRUG_EXPOSURE_END_DATE, DATEADD(day,DAYS_SUPPLY,DRUG_EXPOSURE_START_DATE), DATEADD(day,1,DRUG_EXPOSURE_START_DATE)) as DRUG_EXPOSURE_END_DATE 
+INTO #drugTarget
+FROM @cdm_database_schema.DRUG_EXPOSURE de
+WHERE de.drug_concept_id in (SELECT concept_id from  #Codesets where codeset_id = @drugCodesetId) 
+	AND de.person_id in (select person_id from @eventTable)
+;
+
 select et.event_id, et.person_id, ERAS.era_end_date as end_date
+INTO #strategy_ends
 from @eventTable et
 JOIN 
 (
@@ -6,65 +16,28 @@ JOIN
   from
   (
     select de.person_id, de.drug_exposure_start_date, MIN(e.END_DATE) as era_end_date
-    FROM (
-      -- cteDrugTarget
-       select de.PERSON_ID, DRUG_EXPOSURE_START_DATE, 
-        COALESCE(DRUG_EXPOSURE_END_DATE, DATEADD(day,DAYS_SUPPLY,DRUG_EXPOSURE_START_DATE), DATEADD(day,1,DRUG_EXPOSURE_START_DATE)) as DRUG_EXPOSURE_END_DATE 
-      FROM @cdm_database_schema.DRUG_EXPOSURE de
-      JOIN @eventTable et on de.PERSON_ID = et.PERSON_ID
-      WHERE de.drug_concept_id in (SELECT concept_id from  #Codesets where codeset_id = @drugCodesetId)
-    ) DE
+    FROM #drugTarget DE
     JOIN 
     (
       --cteEndDates
       select PERSON_ID, DATEADD(day,-1 * @gapDays,EVENT_DATE) as END_DATE -- unpad the end date by @gapDays
       FROM
       (
-        select E1.PERSON_ID, E1.EVENT_DATE, COALESCE(E1.START_ORDINAL,MAX(E2.START_ORDINAL)) START_ORDINAL, E1.OVERALL_ORD 
-        FROM 
-        (
-          select PERSON_ID, EVENT_DATE, EVENT_TYPE, 
-          START_ORDINAL,
-          ROW_NUMBER() OVER (PARTITION BY PERSON_ID ORDER BY EVENT_DATE, EVENT_TYPE) AS OVERALL_ORD -- this re-numbers the inner UNION so all rows are numbered ordered by the event date
-          from
-          (
-            -- select the start dates, assigning a row number to each
-            Select PERSON_ID, DRUG_EXPOSURE_START_DATE AS EVENT_DATE, 0 as EVENT_TYPE, ROW_NUMBER() OVER (PARTITION BY PERSON_ID ORDER BY DRUG_EXPOSURE_START_DATE) as START_ORDINAL
-            from (
-              -- cteDrugTarget
-               select de.PERSON_ID, DRUG_EXPOSURE_START_DATE, 
-                COALESCE(DRUG_EXPOSURE_END_DATE, DATEADD(day,DAYS_SUPPLY,DRUG_EXPOSURE_START_DATE), DATEADD(day,1,DRUG_EXPOSURE_START_DATE)) as DRUG_EXPOSURE_END_DATE 
-              FROM @cdm_database_schema.DRUG_EXPOSURE de
-              JOIN @eventTable et on de.PERSON_ID = et.PERSON_ID
-              WHERE de.drug_concept_id in (SELECT concept_id from  #Codesets where codeset_id = @drugCodesetId)
-            ) D
+				select PERSON_ID, EVENT_DATE, EVENT_TYPE, 
+				MAX(START_ORDINAL) OVER (PARTITION BY PERSON_ID ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING) AS start_ordinal,
+				ROW_NUMBER() OVER (PARTITION BY PERSON_ID ORDER BY EVENT_DATE, EVENT_TYPE) AS OVERALL_ORD -- this re-numbers the inner UNION so all rows are numbered ordered by the event date
+				from
+				(
+					-- select the start dates, assigning a row number to each
+					Select PERSON_ID, DRUG_EXPOSURE_START_DATE AS EVENT_DATE, 0 as EVENT_TYPE, ROW_NUMBER() OVER (PARTITION BY PERSON_ID ORDER BY DRUG_EXPOSURE_START_DATE) as START_ORDINAL
+					from #drugTarget D
 
-            UNION ALL
+					UNION ALL
 
-            -- add the end dates with NULL as the row number, padding the end dates by @gapDays to allow a grace period for overlapping ranges.
-            select PERSON_ID, DATEADD(day,@gapDays,DRUG_EXPOSURE_END_DATE), 1 as EVENT_TYPE, NULL
-            FROM (
-              -- cteDrugTarget
-               select de.PERSON_ID, DRUG_EXPOSURE_START_DATE, 
-                COALESCE(DRUG_EXPOSURE_END_DATE, DATEADD(day,DAYS_SUPPLY,DRUG_EXPOSURE_START_DATE), DATEADD(day,1,DRUG_EXPOSURE_START_DATE)) as DRUG_EXPOSURE_END_DATE 
-              FROM @cdm_database_schema.DRUG_EXPOSURE de
-              JOIN @eventTable et on de.PERSON_ID = et.PERSON_ID
-              WHERE de.drug_concept_id in (SELECT concept_id from  #Codesets where codeset_id = @drugCodesetId)
-            ) D
-          ) RAWDATA
-        ) E1
-        LEFT JOIN (
-          Select PERSON_ID, DRUG_EXPOSURE_START_DATE AS EVENT_DATE, ROW_NUMBER() OVER (PARTITION BY PERSON_ID ORDER BY DRUG_EXPOSURE_START_DATE) as START_ORDINAL
-          from (
-            -- cteDrugTarget
-             select de.PERSON_ID, DRUG_EXPOSURE_START_DATE, 
-              COALESCE(DRUG_EXPOSURE_END_DATE, DATEADD(day,DAYS_SUPPLY,DRUG_EXPOSURE_START_DATE), DATEADD(day,1,DRUG_EXPOSURE_START_DATE)) as DRUG_EXPOSURE_END_DATE 
-            FROM @cdm_database_schema.DRUG_EXPOSURE de
-            JOIN @eventTable et on de.PERSON_ID = et.PERSON_ID
-            WHERE de.drug_concept_id in (SELECT concept_id from  #Codesets where codeset_id = @drugCodesetId)
-          ) D
-        ) E2 ON E1.PERSON_ID = E2.PERSON_ID AND E2.EVENT_DATE <= E1.EVENT_DATE
-        GROUP BY E1.PERSON_ID, E1.EVENT_DATE, E1.START_ORDINAL, E1.OVERALL_ORD
+					-- add the end dates with NULL as the row number, padding the end dates by @gapDays to allow a grace period for overlapping ranges.
+					select PERSON_ID, DATEADD(day,@gapDays,DRUG_EXPOSURE_END_DATE), 1 as EVENT_TYPE, NULL
+					FROM #drugTarget D
+				) RAWDATA
       ) E
       WHERE 2 * E.START_ORDINAL - E.OVERALL_ORD = 0
     ) E on DE.PERSON_ID = E.PERSON_ID and E.END_DATE >= DE.DRUG_EXPOSURE_START_DATE
@@ -72,5 +45,7 @@ JOIN
   ) ENDS
   GROUP BY ENDS.person_id, ENDS.era_end_date
 ) ERAS on ERAS.person_id = et.person_id 
-WHERE et.start_date between ERAS.era_start_date and ERAS.era_end_date
+WHERE et.start_date between ERAS.era_start_date and ERAS.era_end_date;
 
+TRUNCATE TABLE #drugTarget;
+DROP TABLE #drugTarget;

--- a/src/main/resources/resources/cohortdefinition/sql/dateOffsetStrategy.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/dateOffsetStrategy.sql
@@ -1,3 +1,6 @@
+-- date offset strategy
+
 select event_id, person_id, 
   case when DATEADD(day,@offset,@dateField) > start_date then DATEADD(day,@offset,@dateField) else start_date end as end_date
-from @eventTable
+INTO #strategy_ends
+from @eventTable;

--- a/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/generateCohort.sql
@@ -15,14 +15,8 @@ FROM
 @QualifiedLimitFilter
 ;
 
+--- Inclusion Rule Inserts
 
-create table #inclusionRuleCohorts 
-(
-  inclusion_rule_id bigint,
-  person_id bigint,
-  event_id bigint
-)
-;
 @inclusionCohortInserts
 
 with cteIncludedEvents(event_id, person_id, start_date, end_date, op_start_date, op_end_date, ordinal) as
@@ -46,37 +40,83 @@ FROM cteIncludedEvents Results
 @ResultLimitFilter
 ;
 
--- Apply end date stratagies
--- by default, all events extend to the op_end_date.
-select event_id, person_id, op_end_date as end_date
-into #cohort_ends
-from #included_events;
+@strategy_ends_temp_tables
 
-@strategyInserts
-
-@censoringInserts
-
-with collapse_input (person_id, start_date, end_date) as
+-- generate cohort periods into #final_cohort
+with cohort_ends (event_id, person_id, end_date) as
+(
+	-- cohort exit dates
+  @cohort_end_unions
+),
+first_ends (person_id, start_date, end_date) as
 (
 	select F.person_id, F.start_date, F.end_date
 	FROM (
 	  select I.event_id, I.person_id, I.start_date, E.end_date, row_number() over (partition by I.person_id, I.event_id order by E.end_date) as ordinal 
 	  from #included_events I
-	  join #cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
+	  join cohort_ends E on I.event_id = E.event_id and I.person_id = E.person_id and E.end_date >= I.start_date
 	) F
 	WHERE F.ordinal = 1
 )
 select person_id, start_date, end_date
-into #collapse_input
-from collapse_input
-;
+INTO #cohort_rows
+from first_ends;
 
-@collapseConstructor
+with cteEndDates (person_id, end_date) AS -- the magic
+(	
+	SELECT
+		person_id
+		, DATEADD(day,-1 * @eraconstructorpad, event_date)  as end_date
+	FROM
+	(
+		SELECT
+			person_id
+			, event_date
+			, event_type
+			, MAX(start_ordinal) OVER (PARTITION BY person_id ORDER BY event_date, event_type ROWS UNBOUNDED PRECEDING) AS start_ordinal 
+			, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY event_date, event_type) AS overall_ord
+		FROM
+		(
+			SELECT
+				person_id
+				, start_date AS event_date
+				, -1 AS event_type
+				, ROW_NUMBER() OVER (PARTITION BY person_id ORDER BY start_date) AS start_ordinal
+			FROM #cohort_rows
+		
+			UNION ALL
+		
+
+			SELECT
+				person_id
+				, DATEADD(day,@eraconstructorpad,end_date) as end_date
+				, 1 AS event_type
+				, NULL
+			FROM #cohort_rows
+		) RAWDATA
+	) e
+	WHERE (2 * e.start_ordinal) - e.overall_ord = 0
+),
+cteEnds (person_id, start_date, end_date) AS
+(
+	SELECT
+		 c.person_id
+		, c.start_date
+		, MIN(e.end_date) AS era_end_date
+	FROM #cohort_rows c
+	JOIN cteEndDates e ON c.person_id = e.person_id AND e.end_date >= c.start_date
+	GROUP BY c.person_id, c.start_date
+)
+select person_id, min(start_date) as start_date, end_date
+into #final_cohort
+from cteEnds
+group by person_id, end_date
+;
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
 select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date
-FROM @output_table CO --@output: change depending on what is selected for collapse construction
+FROM #final_cohort CO
 ;
 
 {@generateStats != 0}?{
@@ -126,14 +166,13 @@ FROM
 ;
 }
 
-TRUNCATE TABLE #collapse_input;
-DROP TABLE #collapse_input;
+@strategy_ends_cleanup
 
-TRUNCATE TABLE #collapse_output;
-DROP TABLE #collapse_output;
+TRUNCATE TABLE #cohort_rows;
+DROP TABLE #cohort_rows;
 
-TRUNCATE TABLE #cohort_ends;
-DROP TABLE #cohort_ends;
+TRUNCATE TABLE #final_cohort;
+DROP TABLE #final_cohort;
 
 TRUNCATE TABLE #inclusionRuleCohorts;
 DROP TABLE #inclusionRuleCohorts;

--- a/src/main/resources/resources/cohortdefinition/sql/inclusionrule.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/inclusionrule.sql
@@ -1,5 +1,5 @@
-INSERT INTO #inclusionRuleCohorts (inclusion_rule_id, person_id, event_id)
 select @inclusion_rule_id as inclusion_rule_id, person_id, event_id
+INTO #InclusionRuleCohort_@inclusion_rule_id
 FROM 
 (
   select pe.person_id, pe.event_id


### PR DESCRIPTION
This PR introduces several performance optimizations related to cohort generation.

@gowthamrao : I had to extract the generic era building sql into something non-generic and in-line in the generation sql because some of the optimizations required that we split the parts of the era building query into separate temp tables.  Also, there was a performance problem when using the dense_rank() function to generate a surrogate groupId key:  by creating a join key within the query, we lose index/partition performance on systems that partition by person_id.    I left the original era builder query in the codebase, my hope is that we can find a way to create the era building logic that maintains the partitioning and joins by the underlying columns because that was a very good idea and contribution you and your team made.  Please let me know if you have any questions.

-Chris
