### PR TITLE
Domain type exclusions and query optimizations.

### DIFF
--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -642,7 +642,7 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     );
 		
 		// join type is LEFT when counts of 0 or 'at most' is specified
-		String joinType = (corelatedCriteria.occurrence.type == 1 || corelatedCriteria.occurrence.count == 0) ?  "LEFT" : "INNER";
+		String joinType = (corelatedCriteria.occurrence.type == Occurrence.AT_MOST || corelatedCriteria.occurrence.count == 0) ?  "LEFT" : "INNER";
     
     query = StringUtils.replace(query, "@joinType", joinType);
 

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -486,20 +486,20 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
       if (group.type.equalsIgnoreCase("ANY")) // count must be > 0 for an 'ANY' criteria
         occurrenceCountClause += "> 0"; 
 
-      if (group.type.toUpperCase().startsWith("AT_"))
-      {
-        if (group.type.toUpperCase().endsWith("LEAST"))
-          occurrenceCountClause += ">= " + group.count;
-				else {
-          occurrenceCountClause += "<= " + group.count;
+			if (group.type.toUpperCase().startsWith("AT_")) {
+				if (group.type.toUpperCase().endsWith("LEAST")) { // AT_LEAST
+					occurrenceCountClause += ">= " + group.count;
+				} else { // AT_MOST, which includes zero
+					occurrenceCountClause += "<= " + group.count;
 					joinType = "LEFT";
 				}
-				
-				if (group.count == 0) {
-					joinType = "LEFT"; //if you are looking for a zero count, you need to do a left join
+
+				if (group.count == 0) { //if you are looking for a zero count within an AT_LEAST/AT_MOST, you need to do a left join
+					joinType = "LEFT";
 				}
-      }
-      query = StringUtils.replace(query, "@occurrenceCountClause", occurrenceCountClause);
+			}
+
+			query = StringUtils.replace(query, "@occurrenceCountClause", occurrenceCountClause);
 			query = StringUtils.replace(query, "@joinType", joinType);
     }
     else // query group is empty so replace group query with a friendly default
@@ -515,8 +515,8 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
   private String getInclusionRuleQuery(CriteriaGroup inclusionRule)
   {
     String resultSql = INCLUSION_RULE_QUERY_TEMPLATE;
-		String additionalCriteriaQuery = "\nJOIN (\n" + getCriteriaGroupQuery(inclusionRule, "#qualified_events") + ") AC on AC.person_id = pe.person_id AND AC.event_id = pe.event_id";
-		additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);
+    String additionalCriteriaQuery = "\nJOIN (\n" + getCriteriaGroupQuery(inclusionRule, "#qualified_events") + ") AC on AC.person_id = pe.person_id AND AC.event_id = pe.event_id";
+    additionalCriteriaQuery = StringUtils.replace(additionalCriteriaQuery,"@indexId", "" + 0);
     resultSql = StringUtils.replace(resultSql, "@additionalCriteriaQuery", additionalCriteriaQuery);
     return resultSql;
   }

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ConditionOccurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ConditionOccurrence.java
@@ -45,6 +45,9 @@ public class ConditionOccurrence extends Criteria {
   @JsonProperty("ConditionType")
   public Concept[] conditionType;
 
+  @JsonProperty("ConditionTypeExclude")
+  public boolean conditionTypeExclude = false;
+	
   @JsonProperty("StopReason")
   public TextFilter stopReason;
 

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CriteriaGroup.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CriteriaGroup.java
@@ -40,4 +40,8 @@ public class CriteriaGroup {
 
   @JsonProperty("Groups")
   public CriteriaGroup[] groups = new CriteriaGroup[0];
+	
+	public boolean isEmpty() {
+		return !(criteriaList.length > 0 || demographicCriteriaList.length > 0 || groups.length > 0);
+	}
 }

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Death.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Death.java
@@ -35,6 +35,9 @@ public class Death extends Criteria {
   @JsonProperty("DeathType")
   public Concept[] deathType;
 
+  @JsonProperty("DeathTypeExclude")
+  public boolean deathTypeExclude = false;
+
   @JsonProperty("DeathSourceConcept")
   public Integer deathSourceConcept;
 

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DeviceExposure.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DeviceExposure.java
@@ -42,7 +42,10 @@ public class DeviceExposure extends Criteria {
   @JsonProperty("DeviceType")
   public Concept[] deviceType;
 
-  @JsonProperty("UniqueDeviceId")
+  @JsonProperty("DeviceTypeExclude")
+  public boolean deviceTypeExclude = false;
+
+	@JsonProperty("UniqueDeviceId")
   public TextFilter uniqueDeviceId;
 
   @JsonProperty("Quantity")

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DrugExposure.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DrugExposure.java
@@ -43,6 +43,9 @@ public class DrugExposure extends Criteria {
   @JsonProperty("DrugType")
   public Concept[] drugType;
 
+  @JsonProperty("DrugTypeExclude")
+  public boolean drugTypeExclude = false;
+	
   @JsonProperty("StopReason")
   public TextFilter stopReason;
   

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Measurement.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Measurement.java
@@ -39,6 +39,9 @@ public class Measurement extends Criteria {
   @JsonProperty("MeasurementType")
   public Concept[] measurementType;
 
+  @JsonProperty("MeasurementTypeExclude")
+  public boolean measurementTypeExclude = false;
+	
   @JsonProperty("Operator")
   public Concept[] operator;
 

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Observation.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Observation.java
@@ -38,6 +38,9 @@ public class Observation extends Criteria {
 
   @JsonProperty("ObservationType")
   public Concept[] observationType;
+	
+  @JsonProperty("ObservationTypeExclude")
+  public boolean observationTypeExclude = false;
 
   @JsonProperty("ValueAsNumber")
   public NumericRange valueAsNumber;

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Occurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Occurrence.java
@@ -25,6 +25,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author cknoll1
  */
 public class Occurrence {
+	public static final int EXACTLY = 0;
+	public static final int AT_MOST = 1;
+	public static final int AT_LEAST = 2;
+	
   @JsonProperty("Type")
   public int type;
 

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ProcedureOccurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ProcedureOccurrence.java
@@ -38,6 +38,9 @@ public class ProcedureOccurrence extends Criteria {
 
   @JsonProperty("ProcedureType")
   public Concept[] procedureType;
+	
+  @JsonProperty("ProcedureTypeExclude")
+  public boolean procedureTypeExclude = false;
 
   @JsonProperty("Modifier")
   public Concept[] modifier;

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Specimen.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Specimen.java
@@ -38,6 +38,9 @@ public class Specimen extends Criteria {
   
   @JsonProperty("SpecimenType")  
   public Concept[] specimenType;
+	
+  @JsonProperty("SpecimenTypeExclude")
+  public boolean specimenTypeExclude = false;
 
   @JsonProperty("Quantity")  
   public NumericRange quantity;

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/VisitOccurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/VisitOccurrence.java
@@ -42,6 +42,9 @@ public class VisitOccurrence extends Criteria {
   @JsonProperty("VisitType")
   public Concept[] visitType;
 
+  @JsonProperty("VisitTypeExclude")
+  public boolean visitTypeExclude = false;
+	
   @JsonProperty("VisitSourceConcept")
   public Integer visitSourceConcept;
 

--- a/src/main/resources/resources/cohortdefinition/sql/additionalCriteria.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/additionalCriteria.sql
@@ -1,7 +1,7 @@
 -- Begin Correlated Criteria
 SELECT @indexId as index_id, p.person_id, p.event_id
 FROM @eventTable P
-LEFT JOIN
+@joinType JOIN
 (
   @criteriaQuery
 ) A on A.person_id = P.person_id and @windowCriteria

--- a/src/main/resources/resources/cohortdefinition/sql/groupQuery.sql
+++ b/src/main/resources/resources/cohortdefinition/sql/groupQuery.sql
@@ -4,7 +4,7 @@ FROM
 (
   select E.person_id, E.event_id 
   FROM @eventTable E
-  LEFT JOIN
+  @joinType JOIN
   (
     @criteriaQueries
   ) CQ on E.person_id = CQ.person_id and E.event_id = CQ.event_id


### PR DESCRIPTION
Allow type concepts to be used as exclusions.
Optimization: apply left join only when looking for counts that might be 0.
Usability: do not create subquery for empty criteria groups.

Fixes #40.