### PR TITLE
Modified CriteriaGroup JSON Seralization

### DIFF
--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CriteriaGroup.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CriteriaGroup.java
@@ -18,6 +18,7 @@
  */
 package org.ohdsi.circe.cohortdefinition;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -41,6 +42,7 @@ public class CriteriaGroup {
   @JsonProperty("Groups")
   public CriteriaGroup[] groups = new CriteriaGroup[0];
 	
+  @JsonIgnore
 	public boolean isEmpty() {
 		return !(criteriaList.length > 0 || demographicCriteriaList.length > 0 || groups.length > 0);
 	}


### PR DESCRIPTION
When serializing a CohortExpression, I found that the CriteriaGroup was inserting an extraneous element:

```
"AdditionalCriteria": {
       "empty": true,
       "Type": "ANY",
       "Count": null,
       "CriteriaList": [],
       "DemographicCriteriaList": [],
       "Groups": []
},

```

Note the `"empty":true` property above. This was causing issues when attempting to use `CohortExpression.fromJson()` to re-hydrate the definition. I modified the CriteriaGroup to ignore the `isEmpty` function in the class and that fixed the issue.