### PR TITLE
fix: the wrong insert clause is generated in case empty concepts list.

### DIFF
--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -173,10 +173,11 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
         String conceptSetInsert = String.format("SELECT %d as codeset_id, c.concept_id FROM (%s) C", cs.id, conceptExpressionQuery);
         codesetInserts.add(conceptSetInsert);
       }
+        codesetQuery = StringUtils.replace(codesetQuery, "@codesetInserts", "INSERT INTO #Codesets (codeset_id, concept_id)\n"
+                + StringUtils.join(codesetInserts, " UNION ALL \n")) + ";";
+    } else {
+        codesetQuery = StringUtils.replace(CODESET_QUERY_TEMPLATE, "@codesetInserts", StringUtils.EMPTY);
     }
-
-    codesetQuery = StringUtils.replace(codesetQuery, "@codesetInserts", "INSERT INTO #Codesets (codeset_id, concept_id)\n"
-            + StringUtils.join(codesetInserts, " UNION ALL \n")) + ";";
     return codesetQuery;
   }
 

--- a/src/test/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilderTest.java
+++ b/src/test/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilderTest.java
@@ -1,0 +1,73 @@
+package org.ohdsi.circe.cohortdefinition;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.ohdsi.circe.vocabulary.ConceptSetExpression;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CohortExpressionQueryBuilderTest {
+
+    private CohortExpressionQueryBuilder cohortExpressionQueryBuilder = new CohortExpressionQueryBuilder();
+
+    @Test
+    public void getCodesetQuery() {
+
+        ConceptSet conceptSets[] = {
+                createConceptSet(1, "name1"),
+                createConceptSet(2, "name2")
+        };
+
+        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(conceptSets);
+        assertThat(codesetQuery, containsString("CREATE TABLE #Codesets (\n" +
+                "  codeset_id int NOT NULL,\n" +
+                "  concept_id bigint NOT NULL\n" +
+                ")\n;"));
+        assertThat(codesetQuery, containsString("INSERT INTO"));
+        assertThat(codesetQuery, containsString("SELECT 1"));
+        assertThat(codesetQuery, containsString("UNION ALL"));
+        assertThat(codesetQuery, containsString("SELECT 2"));
+    }
+
+    @Test
+    public void getCodesetQueryEmptyConceptSets() {
+
+        ConceptSet conceptSets[] = {};
+
+        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(conceptSets);
+
+        assertThat(codesetQuery, equalTo("CREATE TABLE #Codesets (\n" +
+                "  codeset_id int NOT NULL,\n" +
+                "  concept_id bigint NOT NULL\n" +
+                ")\n;\n\n\n"));
+    }
+
+    @Test
+    public void getCodesetQueryNullConceptSets() {
+
+        ConceptSet conceptSets[] = {};
+
+        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(conceptSets);
+
+        assertThat(codesetQuery, equalTo("CREATE TABLE #Codesets (\n" +
+                "  codeset_id int NOT NULL,\n" +
+                "  concept_id bigint NOT NULL\n" +
+                ")\n;\n\n\n"));
+    }
+
+    private ConceptSet createConceptSet(int id, String name) {
+
+        ConceptSet conceptSet1 = new ConceptSet();
+        conceptSet1.id = id;
+        conceptSet1.name = name;
+        conceptSet1.expression = new ConceptSetExpression();
+        conceptSet1.expression.items = new ConceptSetExpression.ConceptSetItem[0];
+
+        return conceptSet1;
+    }
+
+}

--- a/src/test/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilderTest.java
+++ b/src/test/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilderTest.java
@@ -36,9 +36,7 @@ public class CohortExpressionQueryBuilderTest {
     @Test
     public void getCodesetQueryEmptyConceptSets() {
 
-        ConceptSet conceptSets[] = {};
-
-        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(conceptSets);
+        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(new ConceptSet[]{});
 
         assertThat(codesetQuery, equalTo("CREATE TABLE #Codesets (\n" +
                 "  codeset_id int NOT NULL,\n" +
@@ -49,9 +47,7 @@ public class CohortExpressionQueryBuilderTest {
     @Test
     public void getCodesetQueryNullConceptSets() {
 
-        ConceptSet conceptSets[] = {};
-
-        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(conceptSets);
+        String codesetQuery = cohortExpressionQueryBuilder.getCodesetQuery(null);
 
         assertThat(codesetQuery, equalTo("CREATE TABLE #Codesets (\n" +
                 "  codeset_id int NOT NULL,\n" +


### PR DESCRIPTION
the insert was optimized by replacing multiply ` insert-into-selects` with one `insert` and all `select` was grouped by the `union`, but in the case of an empty list the insert clause was invalid:
`insert (a,b);`. 