### PR TITLE
Print-friendly fixes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ohdsi</groupId>
   <artifactId>circe</artifactId>
-  <version>1.11.3-SNAPSHOT</version>
+  <version>1.11.4-SNAPSHOT</version>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/resources/resources/cohortdefinition/printfriendly/utils.ftl
+++ b/src/main/resources/resources/cohortdefinition/printfriendly/utils.ftl
@@ -13,7 +13,7 @@ END Note!!!!
   <#return (options?filter(op -> op.id == id))?first.name>
 </#function>
 
-<#macro indent level=0><#list 1..((level*3)) as x> </#list></#macro>
+<#macro indent level=0><#list 1..((level*4)) as x> </#list></#macro>
 
 <#function codesetName codesetId defaultName>
   <#if !codesetId?has_content>


### PR DESCRIPTION
Adjusted indent to handle cases when numbering goes double-digit.
Updated to 1.13.4.