### PR TITLE
Add concept set selector for all Concept[] attributes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ohdsi</groupId>
   <artifactId>circe</artifactId>
-  <version>1.11.4-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/CohortExpressionQueryBuilder.java
@@ -33,6 +33,7 @@ import org.ohdsi.circe.vocabulary.ConceptSetExpressionQueryBuilder;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildDateRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildNumericRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.dateStringToSql;
+import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getCodesetInExpression;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getConceptIdsFromConcepts;
 
 /**
@@ -486,6 +487,11 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
       whereClauses.add(String.format("P.gender_concept_id in (%s)", StringUtils.join(getConceptIdsFromConcepts(criteria.gender), ",")));
     }
 
+    // genderCS
+    if (criteria.genderCS != null && criteria.genderCS.codesetId != null) {
+      whereClauses.add(getCodesetInExpression(criteria.genderCS.codesetId, "P.gender_concept_id", criteria.genderCS.isExclusion));
+    }
+
     // Race
     if (criteria.race != null && criteria.race.length > 0) {
       whereClauses.add(String.format("P.race_concept_id in (%s)", StringUtils.join(getConceptIdsFromConcepts(criteria.race), ",")));
@@ -494,11 +500,21 @@ public class CohortExpressionQueryBuilder implements IGetCriteriaSqlDispatcher, 
     // Race
     if (criteria.race != null && criteria.race.length > 0) {
       whereClauses.add(String.format("P.race_concept_id in (%s)", StringUtils.join(getConceptIdsFromConcepts(criteria.race), ",")));
+    }
+
+    // raceCS
+    if (criteria.raceCS != null && criteria.raceCS.codesetId != null) {
+      whereClauses.add(getCodesetInExpression(criteria.raceCS.codesetId, "P.gender_concept_id", criteria.raceCS.isExclusion));
     }
 
     // Ethnicity
     if (criteria.ethnicity != null && criteria.ethnicity.length > 0) {
       whereClauses.add(String.format("P.ethnicity_concept_id in (%s)", StringUtils.join(getConceptIdsFromConcepts(criteria.ethnicity), ",")));
+    }
+
+    //EthnicityCS
+    if (criteria.ethnicityCS != null) {
+      whereClauses.add(getCodesetInExpression(criteria.ethnicityCS.codesetId, "P.gender_concept_id", criteria.ethnicityCS.isExclusion));
     }
 
     // occurrenceStartDate

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ConceptSetSelection.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ConceptSetSelection.java
@@ -29,5 +29,5 @@ public class ConceptSetSelection {
   public Integer codesetId;
 
   @JsonProperty("IsExclusion")
-  public Boolean isExclusion;
+  public boolean isExclusion = false;
 }

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ConditionEra.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ConditionEra.java
@@ -55,7 +55,9 @@ public class ConditionEra extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;  
   
-  
+  @JsonProperty("GenderCS")
+    public ConceptSetSelection  genderCS;
+
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {
     return dispatcher.getCriteriaSql(this, options);

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ConditionOccurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ConditionOccurrence.java
@@ -46,6 +46,9 @@ public class ConditionOccurrence extends Criteria {
   @JsonProperty("ConditionType")
   public Concept[] conditionType;
 
+  @JsonProperty("ConditionTypeCS")
+  public ConceptSetSelection conditionTypeCS;
+  
   @JsonProperty("ConditionTypeExclude")
   public Boolean conditionTypeExclude;
 
@@ -61,14 +64,26 @@ public class ConditionOccurrence extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;
 
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
+
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
 
   @JsonProperty("VisitType")
   public Concept[] visitType;
 
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
+
   @JsonProperty("ConditionStatus")
   public Concept[] conditionStatus;
+
+  @JsonProperty("ConditionStatusCS")
+  public ConceptSetSelection conditionStatusCS;
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options)

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Death.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Death.java
@@ -36,6 +36,9 @@ public class Death extends Criteria {
   @JsonProperty("DeathType")
   public Concept[] deathType;
 
+  @JsonProperty("DeathTypeCS")
+  public ConceptSetSelection deathTypeCS;
+
   @JsonProperty("DeathTypeExclude")
   public boolean deathTypeExclude = false;
 
@@ -47,6 +50,9 @@ public class Death extends Criteria {
   
   @JsonProperty("Gender")
   public Concept[] gender;
+  
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
   
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DemographicCriteria.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DemographicCriteria.java
@@ -32,11 +32,20 @@ public class DemographicCriteria {
   @JsonProperty("Gender")
   public Concept[] gender;  
 
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;  
+
   @JsonProperty("Race")
   public Concept[] race;  
 
+  @JsonProperty("RaceCS")
+  public ConceptSetSelection raceCS;  
+
   @JsonProperty("Ethnicity")
   public Concept[] ethnicity;  
+  
+  @JsonProperty("EthnicityCS")
+  public ConceptSetSelection ethnicityCS;  
   
   @JsonProperty("OccurrenceStartDate")
   public DateRange occurrenceStartDate;

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DeviceExposure.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DeviceExposure.java
@@ -43,6 +43,9 @@ public class DeviceExposure extends Criteria {
   @JsonProperty("DeviceType")
   public Concept[] deviceType;
 
+  @JsonProperty("DeviceTypeCS")
+  public ConceptSetSelection deviceTypeCS;
+
   @JsonProperty("DeviceTypeExclude")
   public boolean deviceTypeExclude = false;
 
@@ -61,11 +64,20 @@ public class DeviceExposure extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;
 
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
 
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
+
   @JsonProperty("VisitType")
   public Concept[] visitType;
+
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DoseEra.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DoseEra.java
@@ -43,6 +43,9 @@ public class DoseEra extends Criteria {
   @JsonProperty("Unit")  
   public Concept[] unit;
 
+  @JsonProperty("UnitCS")  
+  public ConceptSetSelection unitCS;
+
   @JsonProperty("DoseValue")  
   public NumericRange doseValue;
 
@@ -57,6 +60,9 @@ public class DoseEra extends Criteria {
 
   @JsonProperty("Gender")
   public Concept[] gender;  
+  
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;  
   
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DrugEra.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DrugEra.java
@@ -58,6 +58,8 @@ public class DrugEra extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;  
   
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;  
   
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/DrugExposure.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/DrugExposure.java
@@ -44,6 +44,9 @@ public class DrugExposure extends Criteria {
   @JsonProperty("DrugType")
   public Concept[] drugType;
 
+  @JsonProperty("DrugTypeCS")
+  public ConceptSetSelection drugTypeCS;
+
   @JsonProperty("DrugTypeExclude")
   public boolean drugTypeExclude = false;
 	
@@ -62,11 +65,17 @@ public class DrugExposure extends Criteria {
   @JsonProperty("RouteConcept")
   public Concept[] routeConcept;
 
+  @JsonProperty("RouteConceptCS")
+  public ConceptSetSelection routeConceptCS;
+
   @JsonProperty("EffectiveDrugDose")
   public NumericRange effectiveDrugDose;  
 
   @JsonProperty("DoseUnit")
   public Concept[] doseUnit;
+
+  @JsonProperty("DoseUnitCS")
+  public ConceptSetSelection doseUnitCS;
 
   @JsonProperty("LotNumber")
   public TextFilter lotNumber;  
@@ -80,11 +89,20 @@ public class DrugExposure extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;
   
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+  
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
 
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
+
   @JsonProperty("VisitType")
   public Concept[] visitType;
+
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options)

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Measurement.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Measurement.java
@@ -40,20 +40,32 @@ public class Measurement extends Criteria {
   @JsonProperty("MeasurementType")
   public Concept[] measurementType;
 
+  @JsonProperty("MeasurementTypeCS")
+  public ConceptSetSelection measurementTypeCS;
+
   @JsonProperty("MeasurementTypeExclude")
   public boolean measurementTypeExclude = false;
 	
   @JsonProperty("Operator")
   public Concept[] operator;
 
+  @JsonProperty("OperatorCS")
+  public ConceptSetSelection operatorCS;
+
   @JsonProperty("ValueAsNumber")
   public NumericRange valueAsNumber;
 
   @JsonProperty("ValueAsConcept")
   public Concept[] valueAsConcept;
-  
+
+  @JsonProperty("ValueAsConceptCS")
+  public ConceptSetSelection valueAsConceptCS;
+
   @JsonProperty("Unit")
   public Concept[] unit;
+  
+  @JsonProperty("UnitCS")
+  public ConceptSetSelection unitCS;
   
   @JsonProperty("RangeLow")
   public NumericRange rangeLow;
@@ -78,12 +90,22 @@ public class Measurement extends Criteria {
   
   @JsonProperty("Gender")
   public Concept[] gender;
-  
+
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
 
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
+
   @JsonProperty("VisitType")
   public Concept[] visitType;
+
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
+
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options)

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Observation.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Observation.java
@@ -40,6 +40,9 @@ public class Observation extends Criteria {
   @JsonProperty("ObservationType")
   public Concept[] observationType;
 	
+  @JsonProperty("ObservationTypeCS")
+  public ConceptSetSelection observationTypeCS;
+	
   @JsonProperty("ObservationTypeExclude")
   public boolean observationTypeExclude = false;
 
@@ -52,11 +55,20 @@ public class Observation extends Criteria {
   @JsonProperty("ValueAsConcept")
   public Concept[] valueAsConcept;
 
+  @JsonProperty("ValueAsConceptCS")
+  public ConceptSetSelection valueAsConceptCS;
+
   @JsonProperty("Qualifier")
   public Concept[] qualifier;
   
+  @JsonProperty("QualifierCS")
+  public ConceptSetSelection qualifierCS;
+  
   @JsonProperty("Unit")
   public Concept[] unit;
+   
+  @JsonProperty("UnitCS")
+  public ConceptSetSelection unitCS;
    
   @JsonProperty("ObservationSourceConcept")
   public Integer observationSourceConcept;
@@ -67,11 +79,21 @@ public class Observation extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;
   
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
 
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
+
   @JsonProperty("VisitType")
   public Concept[] visitType;
+
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
+
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options)

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ObservationPeriod.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ObservationPeriod.java
@@ -43,6 +43,9 @@ public class ObservationPeriod extends Criteria {
   @JsonProperty("PeriodType")
   public Concept[] periodType;
   
+  @JsonProperty("PeriodTypeCS")
+  public ConceptSetSelection periodTypeCS;
+  
   @JsonProperty("PeriodLength")
   public NumericRange periodLength;  
 

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/PayerPlanPeriod.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/PayerPlanPeriod.java
@@ -25,56 +25,60 @@ import org.ohdsi.circe.vocabulary.Concept;
 
 @CdmVersion(range = ">=5.3")
 public class PayerPlanPeriod extends Criteria {
-	@JsonProperty("First")
-	public Boolean first;
-	
-	@JsonProperty("PeriodStartDate")
-	public DateRange periodStartDate;
-	
-	@JsonProperty("PeriodEndDate")
-	public DateRange periodEndDate;
-	
-	@JsonProperty("UserDefinedPeriod")
-	public Period userDefinedPeriod;
-	
-	@JsonProperty("PeriodLength")
-	public NumericRange periodLength;
-	
-	@JsonProperty("AgeAtStart")
-	public NumericRange ageAtStart;
-	
-	@JsonProperty("AgeAtEnd")
-	public NumericRange ageAtEnd;
-	
-	@JsonProperty("Gender")
-	public Concept[] gender;
-	
-	@JsonProperty("PayerConcept")
-	public Integer payerConcept;
-	
-	@JsonProperty("PlanConcept")
-	public Integer planConcept;
-	
-	@JsonProperty("SponsorConcept")
-	public Integer sponsorConcept;
-	
-	@JsonProperty("StopReasonConcept")
-	public Integer stopReasonConcept;
-	
-	@JsonProperty("PayerSourceConcept")
-	public Integer payerSourceConcept;
-	
-	@JsonProperty("PlanSourceConcept")
-	public Integer planSourceConcept;
-	
-	@JsonProperty("SponsorSourceConcept")
-	public Integer sponsorSourceConcept;
-	
-	@JsonProperty("StopReasonSourceConcept")
-	public Integer stopReasonSourceConcept;
-	
-	@Override
-	public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {
-	  return dispatcher.getCriteriaSql(this, options);
-	}
+
+  @JsonProperty("First")
+  public Boolean first;
+
+  @JsonProperty("PeriodStartDate")
+  public DateRange periodStartDate;
+
+  @JsonProperty("PeriodEndDate")
+  public DateRange periodEndDate;
+
+  @JsonProperty("UserDefinedPeriod")
+  public Period userDefinedPeriod;
+
+  @JsonProperty("PeriodLength")
+  public NumericRange periodLength;
+
+  @JsonProperty("AgeAtStart")
+  public NumericRange ageAtStart;
+
+  @JsonProperty("AgeAtEnd")
+  public NumericRange ageAtEnd;
+
+  @JsonProperty("Gender")
+  public Concept[] gender;
+
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+
+  @JsonProperty("PayerConcept")
+  public Integer payerConcept;
+
+  @JsonProperty("PlanConcept")
+  public Integer planConcept;
+
+  @JsonProperty("SponsorConcept")
+  public Integer sponsorConcept;
+
+  @JsonProperty("StopReasonConcept")
+  public Integer stopReasonConcept;
+
+  @JsonProperty("PayerSourceConcept")
+  public Integer payerSourceConcept;
+
+  @JsonProperty("PlanSourceConcept")
+  public Integer planSourceConcept;
+
+  @JsonProperty("SponsorSourceConcept")
+  public Integer sponsorSourceConcept;
+
+  @JsonProperty("StopReasonSourceConcept")
+  public Integer stopReasonSourceConcept;
+
+  @Override
+  public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {
+    return dispatcher.getCriteriaSql(this, options);
+  }
 }

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/ProcedureOccurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/ProcedureOccurrence.java
@@ -39,12 +39,18 @@ public class ProcedureOccurrence extends Criteria {
 
   @JsonProperty("ProcedureType")
   public Concept[] procedureType;
-	
+  
+  @JsonProperty("ProcedureTypeCS")
+  public ConceptSetSelection procedureTypeCS;
+  
   @JsonProperty("ProcedureTypeExclude")
   public boolean procedureTypeExclude = false;
 
   @JsonProperty("Modifier")
   public Concept[] modifier;
+
+  @JsonProperty("ModifierCS")
+  public ConceptSetSelection modifierCS;
 
   @JsonProperty("Quantity")
   public NumericRange quantity;
@@ -57,12 +63,21 @@ public class ProcedureOccurrence extends Criteria {
   
   @JsonProperty("Gender")
   public Concept[] gender;
-  
+
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
 
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
+
   @JsonProperty("VisitType")
   public Concept[] visitType;
+
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options) {

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/Specimen.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/Specimen.java
@@ -39,7 +39,10 @@ public class Specimen extends Criteria {
   
   @JsonProperty("SpecimenType")  
   public Concept[] specimenType;
-	
+
+  @JsonProperty("SpecimenTypeCS")  
+  public ConceptSetSelection specimenTypeCS;
+
   @JsonProperty("SpecimenTypeExclude")
   public boolean specimenTypeExclude = false;
 
@@ -49,11 +52,20 @@ public class Specimen extends Criteria {
   @JsonProperty("Unit")  
   public Concept[] unit;
 
+  @JsonProperty("UnitCS")  
+  public ConceptSetSelection unitCS;
+
   @JsonProperty("AnatomicSite")  
   public Concept[] anatomicSite;
 
+  @JsonProperty("AnatomicSiteCS")  
+  public ConceptSetSelection anatomicSiteCS;
+
   @JsonProperty("DiseaseStatus")  
   public Concept[] diseaseStatus;
+  
+  @JsonProperty("DiseaseStatusCS")  
+  public ConceptSetSelection diseaseStatusCS;
   
   @JsonProperty("SourceId")  
   public TextFilter sourceId;
@@ -66,6 +78,9 @@ public class Specimen extends Criteria {
   
   @JsonProperty("Gender")
   public Concept[] gender;
+
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
 
   @Override
   public String accept(IGetCriteriaSqlDispatcher dispatcher, BuilderOptions options)

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/VisitDetail.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/VisitDetail.java
@@ -21,7 +21,6 @@ package org.ohdsi.circe.cohortdefinition;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.ohdsi.analysis.versioning.CdmVersion;
 import org.ohdsi.circe.cohortdefinition.builders.BuilderOptions;
-import org.ohdsi.circe.vocabulary.Concept;
 
 /**
  *

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/VisitOccurrence.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/VisitOccurrence.java
@@ -44,6 +44,9 @@ public class VisitOccurrence extends Criteria {
   @JsonProperty("VisitType")
   public Concept[] visitType;
 
+  @JsonProperty("VisitTypeCS")
+  public ConceptSetSelection visitTypeCS;
+
   @JsonProperty("VisitTypeExclude")
   public boolean visitTypeExclude = false;
 	
@@ -59,11 +62,20 @@ public class VisitOccurrence extends Criteria {
   @JsonProperty("Gender")
   public Concept[] gender;
   
+  @JsonProperty("GenderCS")
+  public ConceptSetSelection genderCS;
+  
   @JsonProperty("ProviderSpecialty")
   public Concept[] providerSpecialty;
 
+  @JsonProperty("ProviderSpecialtyCS")
+  public ConceptSetSelection providerSpecialtyCS;
+
   @JsonProperty("PlaceOfService")
   public Concept[] placeOfService;
+
+  @JsonProperty("PlaceOfServiceCS")
+  public ConceptSetSelection placeOfServiceCS;
 
   /**
    * ID of Codeset which defines Geo concepts.

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/BuilderUtils.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/BuilderUtils.java
@@ -17,6 +17,7 @@ import org.ohdsi.circe.helper.ResourceHelper;
 public abstract class BuilderUtils {
 
   private final static String CODESET_JOIN_TEMPLATE = "JOIN #Codesets %s on (%s = %s.concept_id and %s.codeset_id = %d)";
+  private final static String CODESET_IN_TEMPLATE = "%s %s in (select concept_id from #Codesets where codeset_id = %d)";
   private final static String DATE_ADJUSTMENT_TEMPLATE = ResourceHelper.GetResourceAsString("/resources/cohortdefinition/sql/dateAdjustment.sql");
   ;
     private final static String STANARD_ALIAS = "cs";
@@ -49,6 +50,10 @@ public abstract class BuilderUtils {
     }
 
     return joinExpression;
+  }
+
+  public static String getCodesetInExpression(Integer codesetId, String conceptColumn, boolean isNegated) {
+    return String.format(CODESET_IN_TEMPLATE, isNegated ? "not":"", conceptColumn, codesetId);
   }
 
   public static String getOperator(String op) {

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/ConditionEraSqlBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/ConditionEraSqlBuilder.java
@@ -14,6 +14,7 @@ import org.ohdsi.circe.cohortdefinition.DateAdjustment;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildDateRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildNumericRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getConceptIdsFromConcepts;
+import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getCodesetInExpression;
 
 public class ConditionEraSqlBuilder<T extends ConditionEra> extends CriteriaSqlBuilder<T> {
 
@@ -93,7 +94,10 @@ public class ConditionEraSqlBuilder<T extends ConditionEra> extends CriteriaSqlB
     List<String> joinClauses = new ArrayList<>();
 
     // join to PERSON
-    if (criteria.ageAtStart != null || criteria.ageAtEnd != null || (criteria.gender != null && criteria.gender.length > 0)) {
+    if (criteria.ageAtStart != null || criteria.ageAtEnd != null || 
+      (criteria.gender != null && criteria.gender.length > 0) ||
+      (criteria.genderCS != null && criteria.genderCS.codesetId != null)
+    ) {
       joinClauses.add("JOIN @cdm_database_schema.PERSON P on C.person_id = P.person_id");
     }
 
@@ -138,6 +142,11 @@ public class ConditionEraSqlBuilder<T extends ConditionEra> extends CriteriaSqlB
     // gender
     if (criteria.gender != null && criteria.gender.length > 0) {
       whereClauses.add(String.format("P.gender_concept_id in (%s)", StringUtils.join(getConceptIdsFromConcepts(criteria.gender), ",")));
+    }
+    
+    // genderCS
+    if (criteria.genderCS != null && criteria.genderCS.codesetId != null) {
+      whereClauses.add(getCodesetInExpression(criteria.genderCS.codesetId, "P.gender_concept_id", criteria.genderCS.isExclusion));
     }
 
     return whereClauses;

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/DrugEraSqlBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/DrugEraSqlBuilder.java
@@ -13,6 +13,7 @@ import org.ohdsi.circe.cohortdefinition.DateAdjustment;
 
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildDateRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildNumericRangeClause;
+import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getCodesetInExpression;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getConceptIdsFromConcepts;
 
 public class DrugEraSqlBuilder<T extends DrugEra> extends CriteriaSqlBuilder<T> {
@@ -101,7 +102,10 @@ public class DrugEraSqlBuilder<T extends DrugEra> extends CriteriaSqlBuilder<T> 
     ArrayList<String> joinClauses = new ArrayList<>();
 
     // join to PERSON
-    if (criteria.ageAtStart != null || criteria.ageAtEnd != null || (criteria.gender != null && criteria.gender.length > 0)) {
+    if (criteria.ageAtStart != null || 
+      criteria.ageAtEnd != null ||
+      (criteria.gender != null && criteria.gender.length > 0) ||
+      (criteria.genderCS != null && criteria.genderCS.codesetId != null)) {
       joinClauses.add("JOIN @cdm_database_schema.PERSON P on C.person_id = P.person_id");
     }
 
@@ -151,6 +155,11 @@ public class DrugEraSqlBuilder<T extends DrugEra> extends CriteriaSqlBuilder<T> 
     // gender
     if (criteria.gender != null && criteria.gender.length > 0) {
       whereClauses.add(String.format("P.gender_concept_id in (%s)", StringUtils.join(getConceptIdsFromConcepts(criteria.gender), ",")));
+    }
+
+    // genderCS
+    if (criteria.genderCS != null && criteria.genderCS.codesetId != null) {
+      whereClauses.add(getCodesetInExpression(criteria.genderCS.codesetId, "P.gender_concept_id", criteria.genderCS.isExclusion));
     }
 
     return whereClauses;

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/ObservationPeriodSqlBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/ObservationPeriodSqlBuilder.java
@@ -14,6 +14,7 @@ import org.ohdsi.circe.cohortdefinition.DateAdjustment;
 
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildDateRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildNumericRangeClause;
+import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getCodesetInExpression;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getConceptIdsFromConcepts;
 
 public class ObservationPeriodSqlBuilder<T extends ObservationPeriod> extends CriteriaSqlBuilder<T> {
@@ -145,6 +146,12 @@ public class ObservationPeriodSqlBuilder<T extends ObservationPeriod> extends Cr
     if (criteria.periodType != null && criteria.periodType.length > 0) {
       ArrayList<Long> conceptIds = getConceptIdsFromConcepts(criteria.periodType);
       whereClauses.add(String.format("C.period_type_concept_id in (%s)", StringUtils.join(conceptIds, ",")));
+    }
+
+    
+    // periodTypeCS
+    if (criteria.periodTypeCS != null && criteria.periodTypeCS.codesetId != null) {
+      whereClauses.add(getCodesetInExpression(criteria.periodTypeCS.codesetId, "C.period_type_concept_id", criteria.periodTypeCS.isExclusion));
     }
 
     // periodLength

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/PayerPlanPeriodSqlBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/PayerPlanPeriodSqlBuilder.java
@@ -14,6 +14,7 @@ import org.ohdsi.circe.cohortdefinition.DateAdjustment;
 
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildDateRangeClause;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.buildNumericRangeClause;
+import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getCodesetInExpression;
 import static org.ohdsi.circe.cohortdefinition.builders.BuilderUtils.getConceptIdsFromConcepts;
 
 public class PayerPlanPeriodSqlBuilder<T extends PayerPlanPeriod> extends CriteriaSqlBuilder<T> {
@@ -135,7 +136,11 @@ public class PayerPlanPeriodSqlBuilder<T extends PayerPlanPeriod> extends Criter
 
     List<String> joinClauses = new ArrayList<>();
 
-    if (criteria.ageAtStart != null || criteria.ageAtEnd != null || (criteria.gender != null && criteria.gender.length > 0)) {
+    if (criteria.ageAtStart != null || 
+      criteria.ageAtEnd != null || 
+      (criteria.gender != null && criteria.gender.length > 0) ||
+      (criteria.genderCS != null && criteria.genderCS.codesetId != null)
+    ) {
       joinClauses.add("JOIN @cdm_database_schema.PERSON P on C.person_id = P.person_id");
     }
 
@@ -196,6 +201,11 @@ public class PayerPlanPeriodSqlBuilder<T extends PayerPlanPeriod> extends Criter
     if (criteria.gender != null && criteria.gender.length > 0) {
       ArrayList<Long> conceptIds = getConceptIdsFromConcepts(criteria.gender);
       whereClauses.add(String.format("P.gender_concept_id in (%s)", StringUtils.join(conceptIds, ",")));
+    }
+
+    // genderCS
+    if (criteria.genderCS != null && criteria.genderCS.codesetId != null) {
+      whereClauses.add(getCodesetInExpression(criteria.genderCS.codesetId, "P.gender_concept_id", criteria.genderCS.isExclusion));
     }
 
     // payer concept

--- a/src/main/resources/resources/cohortdefinition/printfriendly/criteriaTypes.ftl
+++ b/src/main/resources/resources/cohortdefinition/printfriendly/criteriaTypes.ftl
@@ -63,6 +63,7 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 <#macro Death c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
 <#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
 c.deathType??><#local temp>a death type that<#if c.deathTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.deathType/></#local><#local attrs+=[temp]></#if><#if 
 c.deathTypeCS??><#local temp>a death type concept <@inputTypes.ConceptSetSelection selection=c.deathTypeCS /> concept set</#local><#local attrs+=[temp]></#if>

--- a/src/main/resources/resources/cohortdefinition/printfriendly/criteriaTypes.ftl
+++ b/src/main/resources/resources/cohortdefinition/printfriendly/criteriaTypes.ftl
@@ -32,7 +32,7 @@ END Note!!!!
 
 <#macro ConditionEra c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.eraStartDate!{} c.eraEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
 c.eraLength??><#local temp>era length is <@inputTypes.NumericRange range=c.eraLength /> days</#local><#local attrs+=[temp]></#if><#if 
@@ -43,14 +43,18 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro ConditionOccurrence c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{}/></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
-c.conditionType??><#local temp>a condition type that<#if c.conditionTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.conditionType/></#local><#local attrs+=[temp]></#if><#if c.stopReason??> 
-<#local temp>with a stop reason <@inputTypes.TextFilter filter=c.stopReason /></#local><#local attrs+=[temp]></#if><#if c.providerSpecialty??>
-<#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if c.conditionStatus??>
-<#local temp>a condition status that is: <@inputTypes.ConceptList list=c.conditionStatus/></#local><#local attrs+=[temp]></#if><#if c.visitType??>
-<#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if>
+c.conditionType??><#local temp>a condition type that<#if c.conditionTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.conditionType/></#local><#local attrs+=[temp]></#if><#if 
+c.conditionTypeCS??><#local temp>a condition type concept <@inputTypes.ConceptSetSelection selection=c.conditionTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.stopReason??><#local temp>with a stop reason <@inputTypes.TextFilter filter=c.stopReason /></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialtyCS??><#local temp>a provider specialty concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.conditionStatus??><#local temp>a condition status that is: <@inputTypes.ConceptList list=c.conditionStatus/></#local><#local attrs+=[temp]></#if><#if 
+c.conditionStatusCS??><#local temp>a condition status concept <@inputTypes.ConceptSetSelection selection=c.conditionStatusCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 condition occurrence<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any condition")}<#if 
 c.conditionSourceConcept??> (including ${utils.codesetName(c.conditionSourceConcept, "any condition")} source concepts)</#if><#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -58,23 +62,27 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro Death c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
-c.conditionType??><#local temp>a death type that<#if c.deathTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.deathType/></#local><#local attrs+=[temp]></#if>
+c.deathType??><#local temp>a death type that<#if c.deathTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.deathType/></#local><#local attrs+=[temp]></#if><#if 
+c.deathTypeCS??><#local temp>a death type concept <@inputTypes.ConceptSetSelection selection=c.deathTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 death of ${utils.codesetName(c.codesetId!"", "any form")}<#if 
 c.deathSourceConcept??> (including ${utils.codesetName(c.deathSourceConcept, "any form")} source concepts)</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
 c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLabel=utils.codesetName(c.codesetId!"", "any form") /><#else>.</#if></#macro>
 
 <#macro DeviceExposure c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
-c.deviceType??><#local temp>a device type that<#if c.deviceTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.deviceType/></#local><#local attrs+=[temp]></#if><#if c.uniqueDeviceId??> 
-<#local temp>unique device ID <@inputTypes.TextFilter filter=c.uniqueDeviceId /></#local><#local attrs+=[temp]></#if><#if c.quantity??>
-<#local temp>quantity <@inputTypes.NumericRange range=c.quantity /></#local><#local attrs+=[temp]></#if><#if c.providerSpecialty??>
-<#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if c.visitType??>
-<#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if>
+c.deviceType??><#local temp>a device type that<#if c.deviceTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.deviceType/></#local><#local attrs+=[temp]></#if><#if 
+c.deviceTypeCS??><#local temp>a device type concept <@inputTypes.ConceptSetSelection selection=c.deviceTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.uniqueDeviceId??><#local temp>unique device ID <@inputTypes.TextFilter filter=c.uniqueDeviceId /></#local><#local attrs+=[temp]></#if><#if 
+c.quantity??><#local temp>quantity <@inputTypes.NumericRange range=c.quantity /></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialtyCS??><#local temp>a provider specialty concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 device exposure<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any device")}<#if 
 c.deviceSourceConcept??> (including ${utils.codesetName(c.deviceSourceConcept, "any condition")} source concepts)</#if><#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -82,44 +90,50 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro DoseEra c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
-<#local temp><@EventDateCriteria c.eraStartDate!{} c.eraEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if c.unit??>
-<#local temp>unit is: <@inputTypes.ConceptList list=c.unit/></#local><#local attrs+=[temp]></#if><#if c.eraLength??>
-<#local temp>with era length <@inputTypes.NumericRange range=c.eraLength /> days</#local><#local attrs+=[temp]></#if><#if c.doseValue??>
-<#local temp>with dose value <@inputTypes.NumericRange range=c.doseValue /></#local><#local attrs+=[temp]></#if>
+<#local temp><@EventDateCriteria c.eraStartDate!{} c.eraEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
+c.unit??><#local temp>unit is: <@inputTypes.ConceptList list=c.unit/></#local><#local attrs+=[temp]></#if><#if 
+c.unitCS??><#local temp>a unit concept <@inputTypes.ConceptSetSelection selection=c.unitCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.eraLength??><#local temp>with era length <@inputTypes.NumericRange range=c.eraLength /> days</#local><#local attrs+=[temp]></#if><#if
+ c.doseValue??><#local temp>with dose value <@inputTypes.NumericRange range=c.doseValue /></#local><#local attrs+=[temp]></#if>
 dose era<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any drug")}<#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
 c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLabel=utils.codesetName(c.codesetId!"", "any drug") /><#else>.</#if></#macro>
 
 <#macro DrugEra c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
-<#local temp><@EventDateCriteria c.eraStartDate!{} c.eraEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if c.eraLength??>
-<#local temp>with era length <@inputTypes.NumericRange range=c.eraLength /> days</#local><#local attrs+=[temp]></#if><#if c.occurrenceCount??>
-<#local temp>with occurrence count <@inputTypes.NumericRange range=c.occurrenceCount /></#local><#local attrs+=[temp]></#if><#if c.gapDays??>
-<#local temp>with gap days <@inputTypes.NumericRange range=c.gapDays /></#local><#local attrs+=[temp]></#if>
+<#local temp><@EventDateCriteria c.eraStartDate!{} c.eraEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
+c.eraLength??><#local temp>with era length <@inputTypes.NumericRange range=c.eraLength /> days</#local><#local attrs+=[temp]></#if><#if 
+c.occurrenceCount??><#local temp>with occurrence count <@inputTypes.NumericRange range=c.occurrenceCount /></#local><#local attrs+=[temp]></#if><#if 
+c.gapDays??><#local temp>with gap days <@inputTypes.NumericRange range=c.gapDays /></#local><#local attrs+=[temp]></#if>
 drug era<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any drug")}<#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
 c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLabel=utils.codesetName(c.codesetId!"", "any drug") /><#else>.</#if></#macro>
 
 <#macro DrugExposure c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
-c.drugType??><#local temp>a drug type that<#if c.drugTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.drugType/></#local><#local attrs+=[temp]></#if><#if c.refills??>
-<#local temp>with refills <@inputTypes.NumericRange range=c.refills /></#local><#local attrs+=[temp]></#if><#if c.quantity??>
-<#local temp>with quantity <@inputTypes.NumericRange range=c.quantity /></#local><#local attrs+=[temp]></#if><#if c.daysSupply??>
-<#local temp>with days supply <@inputTypes.NumericRange range=c.daysSupply /> days</#local><#local attrs+=[temp]></#if><#if c.effectiveDrugDose??>
-<#local temp>with effective drug dose <@inputTypes.NumericRange range=c.effectiveDrugDose /></#local><#local attrs+=[temp]></#if><#if c.doseUnit??>
-<#local temp>dose unit: <@inputTypes.ConceptList list=c.doseUnit/></#local><#local attrs+=[temp]></#if><#if c.routeConcept??>
-<#local temp>with route: <@inputTypes.ConceptList list=c.routeConcept/></#local><#local attrs+=[temp]></#if><#if c.lotNumber??> 
-<#local temp>lot number <@inputTypes.TextFilter filter=c.lotNumber /></#local><#local attrs+=[temp]></#if><#if c.stopReason??> 
-<#local temp>with a stop reason <@inputTypes.TextFilter filter=c.stopReason /></#local><#local attrs+=[temp]></#if><#if c.providerSpecialty??>
-<#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if c.visitType??>
-<#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if>
+c.drugType??><#local temp>a drug type that<#if c.drugTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.drugType/></#local><#local attrs+=[temp]></#if><#if 
+c.drugTypeCS??><#local temp>a drug type concept <@inputTypes.ConceptSetSelection selection=c.drugTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.refills??><#local temp>with refills <@inputTypes.NumericRange range=c.refills /></#local><#local attrs+=[temp]></#if><#if 
+c.quantity??><#local temp>with quantity <@inputTypes.NumericRange range=c.quantity /></#local><#local attrs+=[temp]></#if><#if 
+c.daysSupply??><#local temp>with days supply <@inputTypes.NumericRange range=c.daysSupply /> days</#local><#local attrs+=[temp]></#if><#if 
+c.effectiveDrugDose??><#local temp>with effective drug dose <@inputTypes.NumericRange range=c.effectiveDrugDose /></#local><#local attrs+=[temp]></#if><#if 
+c.doseUnit??><#local temp>dose unit: <@inputTypes.ConceptList list=c.doseUnit/></#local><#local attrs+=[temp]></#if><#if 
+c.doseUnitCS??><#local temp>a dose unit concept <@inputTypes.ConceptSetSelection selection=c.doseUnitCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.routeConcept??><#local temp>with route: <@inputTypes.ConceptList list=c.routeConcept/></#local><#local attrs+=[temp]></#if><#if 
+c.routeConceptCS??><#local temp>a route concept <@inputTypes.ConceptSetSelection selection=c.routeConceptCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.lotNumber??><#local temp>lot number <@inputTypes.TextFilter filter=c.lotNumber /></#local><#local attrs+=[temp]></#if><#if 
+c.stopReason??><#local temp>with a stop reason <@inputTypes.TextFilter filter=c.stopReason /></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialtyCS??><#local temp>a provider specialty concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 drug exposure<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any drug")}<#if 
 c.drugSourceConcept??> (including ${utils.codesetName(c.drugSourceConcept, "any drug")} source concepts)</#if><#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -133,21 +147,27 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro Measurement c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
 c.measurementType??><#local temp>a measurement type that<#if c.measurementTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.measurementType/></#local><#local attrs+=[temp]></#if><#if 
+c.measurementTypeCS??><#local temp>a measurement type concept <@inputTypes.ConceptSetSelection selection=c.measurementTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.operator??><#local temp>with operator: <@inputTypes.ConceptList list=c.operator/></#local><#local attrs+=[temp]></#if><#if 
+c.operatorCS??><#local temp>an operator concept <@inputTypes.ConceptSetSelection selection=c.operatorCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.valueAsNumber??><#local temp>numeric value <@inputTypes.NumericRange range=c.valueAsNumber /></#local><#local attrs+=[temp]></#if><#if 
 c.unit??><#local temp>unit: <@inputTypes.ConceptList list=c.unit/></#local><#local attrs+=[temp]></#if><#if 
+c.unitCS??><#local temp>a unit concept <@inputTypes.ConceptSetSelection selection=c.unitCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.valueAsConcept??><#local temp>with value as concept: <@inputTypes.ConceptList list=c.valueAsConcept/></#local><#local attrs+=[temp]></#if><#if 
+c.valueAsConceptCS??><#local temp>a value as concept <@inputTypes.ConceptSetSelection selection=c.valueAsConceptCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.rangeLow??><#local temp>low range <@inputTypes.NumericRange range=c.rangeLow /></#local><#local attrs+=[temp]></#if><#if 
 c.rangeHigh??><#local temp>high range <@inputTypes.NumericRange range=c.rangeHigh /></#local><#local attrs+=[temp]></#if><#if 
 c.rangeLowRatio??><#local temp>low range-to-value ratio <@inputTypes.NumericRange range=c.rangeLowRatio /></#local><#local attrs+=[temp]></#if><#if 
 c.rangeHighRatio??><#local temp>high range-to-value ratio <@inputTypes.NumericRange range=c.rangeHighRatio /></#local><#local attrs+=[temp]></#if><#if 
 c.abnormal!false><#local temp>with an abormal result (measurement value falls outside the low and high range)</#local><#local attrs+=[temp]></#if><#if 
 c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
-c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if>
+c.providerSpecialtyCS??><#local temp>a provider speciality concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 measurement<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any measurement")}<#if 
 c.measurementSourceConcept??> (including ${utils.codesetName(c.measurementSourceConcept, "any measurement")} source concepts)</#if><#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -155,17 +175,23 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro Observation c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
 c.observationType??><#local temp>an observation type that<#if c.observationTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.observationType/></#local><#local attrs+=[temp]></#if><#if 
+c.observationTypeCS??><#local temp>an observation type concept <@inputTypes.ConceptSetSelection selection=c.observationTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.valueAsNumber??><#local temp>numeric value <@inputTypes.NumericRange range=c.valueAsNumber /></#local><#local attrs+=[temp]></#if><#if 
 c.unit??><#local temp>unit: <@inputTypes.ConceptList list=c.unit/></#local><#local attrs+=[temp]></#if><#if 
+c.unitCS??><#local temp>an unit concept <@inputTypes.ConceptSetSelection selection=c.unitCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.valueAsConcept??><#local temp>with value as concept: <@inputTypes.ConceptList list=c.valueAsConcept/></#local><#local attrs+=[temp]></#if><#if 
+c.valueAsConceptCS??><#local temp>a value as concept <@inputTypes.ConceptSetSelection selection=c.valueAsConceptCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.valueAsString??><#local temp>with value as string <@inputTypes.TextFilter filter=c.valueAsString /></#local><#local attrs+=[temp]></#if><#if 
 c.qualifier??><#local temp>with qualifier: <@inputTypes.ConceptList list=c.qualifier/></#local><#local attrs+=[temp]></#if><#if 
+c.qualifierCS??><#local temp>a qualifier concept <@inputTypes.ConceptSetSelection selection=c.qualifierCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
-c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if>
+c.providerSpecialtyCS??><#local temp>a provider speciality concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 observation<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any observation")}<#if 
 c.observationSourceConcept??> (including ${utils.codesetName(c.observationSourceConcept, "any observation")} source concepts)</#if><#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -173,11 +199,12 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro ObservationPeriod c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.ageAtStart!{} ageAtEnd=c.ageAtEnd!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.periodStartDate!{} c.periodEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if
 c.userDefinedPeriod??><#local temp><@inputTypes.UserDefinedPeriod c.userDefinedPeriod /></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if><#if 
 c.periodType??><#local temp>period type is: <@inputTypes.ConceptList list=c.periodType/></#local><#local attrs+=[temp]></#if><#if 
+c.periodTypeCS??><#local temp>a period type concept <@inputTypes.ConceptSetSelection selection=c.periodTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.periodLength??><#local temp>with a length <@inputTypes.NumericRange range=c.periodLength /> days</#local><#local attrs+=[temp]></#if>
 observation period<#if isPlural && !(c.first!false)>s</#if><#if 
 c.first!false> (first obsrvation period in person's history)</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -185,14 +212,18 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro ProcedureOccurrence c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
 c.procedureType??><#local temp>a procedure type that<#if c.procedureTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.procedureType/></#local><#local attrs+=[temp]></#if><#if 
+c.procedureTypeCS??><#local temp>a procedure type concept <@inputTypes.ConceptSetSelection selection=c.procedureTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.modifier??><#local temp>with modifier: <@inputTypes.ConceptList list=c.modifier/></#local><#local attrs+=[temp]></#if><#if 
+c.modifierCS??><#local temp>a modifier concept <@inputTypes.ConceptSetSelection selection=c.modifierCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.quantity??><#local temp>with quantity <@inputTypes.NumericRange range=c.quantity /></#local><#local attrs+=[temp]></#if><#if 
 c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
-c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if>
+c.providerSpecialtyCS??><#local temp>a provider speciality concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit occurrence that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if>
 procedure occurrence<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any procedure")}<#if 
 c.procedureSourceConcept??> (including ${utils.codesetName(c.procedureSourceConcept, "any procedure")} source concepts)</#if><#if 
 c.first!false> for the first time in the person's history</#if><#if attrs?size gt 0>, ${attrs?join("; ")}</#if><#if 
@@ -200,14 +231,18 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro Specimen c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
 c.specimenType??><#local temp>a specimen type that<#if c.specimenTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.specimenType/></#local><#local attrs+=[temp]></#if><#if 
+c.specimenTypeCS??><#local temp>a specimen type concept <@inputTypes.ConceptSetSelection selection=c.specimenTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.quantity??><#local temp>with quantity <@inputTypes.NumericRange range=c.quantity /></#local><#local attrs+=[temp]></#if><#if 
 c.unit??><#local temp>with unit: <@inputTypes.ConceptList list=c.unit/></#local><#local attrs+=[temp]></#if><#if 
+c.unitCS??><#local temp>an unit concept <@inputTypes.ConceptSetSelection selection=c.unitCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.anatomicSite??><#local temp>with anatomic site: <@inputTypes.ConceptList list=c.anatomicSite/></#local><#local attrs+=[temp]></#if><#if 
-c.diseaseStatus??><#local temp>with disease status: <@inputTypes.ConceptList list=c.diseaseStatus/></#local><#local attrs+=[temp]></#if><#if
+c.anatomicSiteCS??><#local temp>an anatomic site concept <@inputTypes.ConceptSetSelection selection=c.anatomicSiteCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
+c.diseaseStatus??><#local temp>with disease status: <@inputTypes.ConceptList list=c.diseaseStatus/></#local><#local attrs+=[temp]></#if><#if 
+c.diseaseStatusCS??><#local temp>a disease status concept <@inputTypes.ConceptSetSelection selection=c.diseaseStatusCS /> concept set</#local><#local attrs+=[temp]></#if><#if
 c.sourceId??><#local temp>with source ID <@inputTypes.TextFilter filter=c.sourceId /></#local><#local attrs+=[temp]></#if>
 specimen<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any specimen")}<#if 
 c.specimenSourceConcept??> (including ${utils.codesetName(c.specimenSourceConcept, "any specimen")} source concepts)</#if><#if 
@@ -216,12 +251,14 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro VisitOccurrence c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if 
-c.visitType??><#local temp>a visit type that<#if c.visitTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if
-c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if
-c.visitType??><#local temp>a visit type that is: <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitType??><#local temp>a visit type that<#if c.visitTypeExclude!false> is not:<#else> is:</#if> <@inputTypes.ConceptList list=c.visitType/></#local><#local attrs+=[temp]></#if><#if 
+c.visitTypeCS??><#local temp>a visit type concept <@inputTypes.ConceptSetSelection selection=c.visitTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if
+c.providerSpecialty??><#local temp>a provider specialty that is: <@inputTypes.ConceptList list=c.providerSpecialty/></#local><#local attrs+=[temp]></#if><#if 
+c.providerSpecialtyCS??><#local temp>a provider speciality concept <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if
+c.placeOfServiceCS??><#local temp>a place of service that is <@inputTypes.ConceptSetSelection selection=c.placeOfServiceCS /> concept set</#local><#local attrs+=[temp]></#if><#if 
 c.visitLength??><#local temp>with length <@inputTypes.NumericRange range=c.visitLength /> days</#local><#local attrs+=[temp]></#if>
 visit occurrence<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any visit")}<#if 
 c.visitSourceConcept??> (including ${utils.codesetName(c.visitSourceConcept, "any visit")} source concepts)</#if><#if 
@@ -230,12 +267,12 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#macro VisitDetail c level isPlural=true countCriteria={} indexLabel="cohort entry"><#local attrs = []><#local attrs = []><#if countCriteria?has_content>
 <#local temp><@WindowCriteria countCriteria=countCriteria indexLabel=indexLabel/></#local><#if temp?has_content><#local attrs+=[temp]></#if></#if>
-<#local temp><@AgeGenderCSCriteria ageAtStart=c.age!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
+<#local temp><@AgeGenderCriteria ageAtStart=c.age!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@inputTypes.DateAdjustment da=c.dateAdjustment!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if>
 <#local temp><@EventDateCriteria c.visitDetailStartDate!{} c.visitDetailEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if
 c.visitDetailTypeCS?? && c.visitDetailTypeCS.codesetId??><#local temp>a visit detail type that is <@inputTypes.ConceptSetSelection selection=c.visitDetailTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if
 c.providerSpecialtyCS?? && c.providerSpecialtyCS.codesetId??><#local temp>a provider specialty that is <@inputTypes.ConceptSetSelection selection=c.providerSpecialtyCS /> concept set</#local><#local attrs+=[temp]></#if><#if
-c.placeOfServiceCS?? && c.placeOfServiceCS.codesetId??><#local temp>a place of service that is <@inputTypes.ConceptSetSelection selection=c.visitDetailTypeCS /> concept set</#local><#local attrs+=[temp]></#if><#if
+c.placeOfServiceCS??><#local temp>a place of service that is <@inputTypes.ConceptSetSelection selection=c.placeOfServiceCS /> concept set</#local><#local attrs+=[temp]></#if><#if
 c.visitDetailLength??><#local temp>with length <@inputTypes.NumericRange range=c.visitDetailLength /> days</#local><#local attrs+=[temp]></#if>
 visit detail<#if isPlural && !(c.first!false)>s</#if> of ${utils.codesetName(c.codesetId!"", "any visit detail")}<#if
 c.visitDetailSourceConcept??> (including ${utils.codesetName(c.visitDetailSourceConcept, "any visit")} source concepts)</#if><#if
@@ -247,17 +284,12 @@ c.CorrelatedCriteria??>; <@Group group=c.CorrelatedCriteria level=level indexLab
 
 <#-- Criteria attribute templates -->
 
-<#macro AgeGenderCriteria ageAtStart gender ageAtEnd={}>
+<#macro AgeGenderCriteria ageAtStart gender={} genderCS={} ageAtEnd={}>
 <#if ageAtStart?has_content || ageAtEnd?has_content || gender?has_content>
 who are<#if gender?has_content> <@inputTypes.ConceptList list=gender quote=""/><#if (ageAtStart?has_content || ageAtEnd?has_content) && gender?size gt 1>,</#if></#if><#if 
 ageAtStart?has_content> <@inputTypes.NumericRange range=ageAtStart /> years old<#if ageAtEnd?has_content> at era start and</#if><#if 
-ageAtEnd?has_content> <@inputTypes.NumericRange range=ageAtEnd /> years old at era end</#if></#if></#if></#macro>
-
-<#macro AgeGenderCSCriteria ageAtStart genderCS ageAtEnd={}>
-<#if ageAtStart?has_content || ageAtEnd?has_content>who are <#if 
-ageAtStart?has_content> <@inputTypes.NumericRange range=ageAtStart /> years old<#if ageAtEnd?has_content> at era start and </#if></#if><#if 
-ageAtEnd?has_content><@inputTypes.NumericRange range=ageAtEnd /> years old at era end</#if><#if genderCS?has_content>, and </#if></#if><#if 
-genderCS?has_content>who have gender concept <@inputTypes.ConceptSetSelection selection=genderCS /> concept set</#if></#macro>
+ageAtEnd?has_content> <@inputTypes.NumericRange range=ageAtEnd /> years old at era end</#if></#if><#if genderCS?has_content>; </#if></#if><#if 
+genderCS?has_content>who have gender <@inputTypes.ConceptSetSelection selection=genderCS /> concept set</#if></#macro>
 
 <#macro EventDateCriteria startRange endRange><#if 
 startRange?has_content && endRange?has_content>starting <@inputTypes.DateRange range=startRange /> and ending <@inputTypes.DateRange range=endRange /><#else><#if 
@@ -303,7 +335,7 @@ restrictParts?size gt 0>${restrictParts?join(" and ")}</#if></#macro>
 
 <#-- Demographic Criteria -->
 <#macro DemographicCriteria c level=0 indexLabel = "cohort entry"><#local attrs = []><#local 
-temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#local 
+temp><@AgeGenderCriteria ageAtStart=c.age!{} gender=c.gender!{} genderCS=c.genderCS!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#local 
 temp><@EventDateCriteria c.occurrenceStartDate!{} c.occurrenceEndDate!{} /></#local><#if temp?has_content><#local attrs+=[temp]></#if><#if
 c.race??><#local temp>race is: <@inputTypes.ConceptList list=c.race/></#local><#local attrs+=[temp]></#if><#if
 c.ethnicity??><#local temp>ethnicity is: <@inputTypes.ConceptList list=c.ethnicity/></#local><#local attrs+=[temp]></#if><#if 

--- a/src/main/resources/resources/cohortdefinition/printfriendly/inputTypes.ftl
+++ b/src/main/resources/resources/cohortdefinition/printfriendly/inputTypes.ftl
@@ -109,3 +109,4 @@ p.endDate?has_content><#if !p.startDate?has_content>a user defined</#if> end dat
 <#macro DateAdjustment da><#if 
 da?has_content>starting ${(da.startOffset != 0)?then((da.startOffset?abs + " days " + (da.startOffset < 0)?then("before","after")), "on")}${(da.startWith != da.endWith)?then(" the event ${toDatePart(da.startWith)}","")}<#--
 --> and ending ${(da.endOffset != 0)?then((da.endOffset?abs + " days " + (da.endOffset < 0)?then("before","after")), "on")} the event ${toDatePart(da.endWith)}</#if></#macro>
+

--- a/src/test/java/org/ohdsi/circe/cohortdefinition/builders/CriteriaQuery_5_0_0_Test.java
+++ b/src/test/java/org/ohdsi/circe/cohortdefinition/builders/CriteriaQuery_5_0_0_Test.java
@@ -28,6 +28,7 @@ import org.dbunit.operation.DatabaseOperation;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.ohdsi.circe.AbstractDatabaseTest;
+import org.ohdsi.circe.cohortdefinition.ConceptSetSelection;
 import org.ohdsi.circe.cohortdefinition.ConditionEra;
 import org.ohdsi.circe.cohortdefinition.ConditionOccurrence;
 import org.ohdsi.circe.cohortdefinition.DateAdjustment;
@@ -42,6 +43,7 @@ import org.ohdsi.circe.cohortdefinition.ObservationPeriod;
 import org.ohdsi.circe.cohortdefinition.PayerPlanPeriod;
 import org.ohdsi.circe.cohortdefinition.Period;
 import org.ohdsi.circe.cohortdefinition.ProcedureOccurrence;
+import org.ohdsi.circe.cohortdefinition.Specimen;
 import org.ohdsi.circe.cohortdefinition.VisitOccurrence;
 import org.ohdsi.sql.SqlRender;
 import org.ohdsi.sql.SqlTranslate;
@@ -58,6 +60,11 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   private final static Logger log = LoggerFactory.getLogger(CriteriaQuery_5_0_0_Test.class);
   private static final String CDM_DDL_PATH = "/ddl/cdm_v5.0.sql";
   private static final String TEMP_DDL_PATH = "/criteria/temp.sql";
+  private static final ConceptSetSelection CONCEPTSET_1 = null;
+  private static final ConceptSetSelection CONCEPTSET_2 = null;
+  private static final ConceptSetSelection CONCEPTSET_3 = null;
+  private static final ConceptSetSelection CONCEPTSET_4 = null;
+  
 
   private String renderQuery(String query) {
     String result = StringUtils.replace(query, "#Codesets", "temp.codesets");
@@ -83,6 +90,13 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     jdbcTemplate = new JdbcTemplate(getDataSource());
     prepareSchema("cdm", CDM_DDL_PATH);
     prepareSchema("temp", TEMP_DDL_PATH);
+  }
+  
+  private ConceptSetSelection createConceptSetSelection(Integer id, boolean isExcluded) {
+    ConceptSetSelection css = new ConceptSetSelection();
+    css.codesetId = id;
+    css.isExclusion = isExcluded;
+    return css;
   }
 
   @Test
@@ -135,6 +149,43 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   }
   
   @Test
+  public void testConditionEraConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/conditionEraConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    ConditionEra criteria = new ConditionEra();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    ConditionEraSqlBuilder<ConditionEra> builder = new ConditionEraSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("conditionEra.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/conditionEraConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
   public void testConditionOccurrenceDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
       "/datasets/vocabulary.json",
@@ -179,6 +230,48 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   }
   
   @Test
+  public void testConditionOccurrenceConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/conditionOccurrenceConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    ConditionOccurrence criteria = new ConditionOccurrence();
+    criteria.codesetId = 1;
+    criteria.conditionTypeCS = createConceptSetSelection(1,false);
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+    
+
+    ConditionOccurrenceSqlBuilder<ConditionOccurrence> builder = new ConditionOccurrenceSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("conditionOccurrence.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/conditionOccurrenceConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+  
+  @Test
   public void testDeathDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
       "/datasets/vocabulary.json",
@@ -216,6 +309,46 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Load expected data from an XML dataset
     final String[] testDataSetsVerify = new String[]{"/criteria/deathDateOffset_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  
+  @Test
+  public void testDeathConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/deathConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    Death criteria = new Death();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.deathTypeCS = createConceptSetSelection(1,false);
+
+    DeathSqlBuilder<Death> builder = new DeathSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("death.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/deathConceptSet_VERIFY.json"};
     final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
 
     // Assert actual database table match expected table
@@ -267,6 +400,47 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   }
 
   @Test
+  public void testDeviceExposureConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/deviceExposureConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    DeviceExposure criteria = new DeviceExposure();
+    criteria.codesetId = 1;
+    criteria.deviceTypeCS = createConceptSetSelection(1,false);
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+
+    DeviceExposureSqlBuilder<DeviceExposure> builder = new DeviceExposureSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("deviceExposure.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/deviceExposureConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
   public void testDoseEraDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
       "/datasets/vocabulary.json",
@@ -304,6 +478,46 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Load expected data from an XML dataset
     final String[] testDataSetsVerify = new String[]{"/criteria/doseEraDateOffset_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }  
+
+  @Test
+  public void testDoseEraConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/doseEraConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    DoseEra criteria = new DoseEra();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.unitCS = createConceptSetSelection(3,false);
+    
+
+    DoseEraSqlBuilder<DoseEra> builder = new DoseEraSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("doseEra.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/doseEraConceptSet_VERIFY.json"};
     final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
 
     // Assert actual database table match expected table
@@ -355,6 +569,44 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   }
 
   @Test
+  public void testDrugEraConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/drugEraConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    DrugEra criteria = new DrugEra();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+
+    DrugEraSqlBuilder<DrugEra> builder = new DrugEraSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("drugEra.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/drugEraConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
   public void testDrugExposureDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
       "/datasets/vocabulary.json",
@@ -392,6 +644,49 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Load expected data from an XML dataset
     final String[] testDataSetsVerify = new String[]{"/criteria/drugExposureDateOffset_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }  
+
+  @Test
+  public void testDrugExposureConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/drugExposureConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    DrugExposure criteria = new DrugExposure();
+    criteria.codesetId = 1;
+    criteria.drugTypeCS = createConceptSetSelection(2,false);
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.routeConceptCS = createConceptSetSelection(3,false);
+    criteria.doseUnitCS = createConceptSetSelection(2,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+
+    DrugExposureSqlBuilder<DrugExposure> builder = new DrugExposureSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("drugExposure.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/drugExposureConceptSet_VERIFY.json"};
     final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
 
     // Assert actual database table match expected table
@@ -443,6 +738,50 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   }
 
   @Test
+  public void testMeasurementConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/measurementConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    Measurement criteria = new Measurement();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.operatorCS = createConceptSetSelection(3,false);
+    criteria.valueAsConceptCS = createConceptSetSelection(2,false);
+    criteria.unitCS = createConceptSetSelection(1,false);
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+    
+    MeasurementSqlBuilder<Measurement> builder = new MeasurementSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("measurement.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/measurementConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
   public void testObservationDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
       "/datasets/vocabulary.json",
@@ -481,6 +820,50 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Load expected data from an XML dataset
     final String[] testDataSetsVerify = new String[]{"/criteria/observationDateOffset_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
+  public void testObservationConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/observationConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    Observation criteria = new Observation();
+    criteria.codesetId = 1;
+    criteria.observationTypeCS = createConceptSetSelection(1,false);
+    criteria.qualifierCS = createConceptSetSelection(3,false);
+    criteria.valueAsConceptCS = createConceptSetSelection(2,false);
+    criteria.unitCS = createConceptSetSelection(1,false);
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+
+    ObservationSqlBuilder<Observation> builder = new ObservationSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("observation.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/observationConceptSet_VERIFY.json"};
     final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
 
     // Assert actual database table match expected table
@@ -534,6 +917,43 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Load expected data from an XML dataset
     final String[] testDataSetsVerify = new String[]{"/criteria/observationPeriodDateOffset_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
+  public void testObservationPeriodConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/observationPeriodConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    ObservationPeriod criteria = new ObservationPeriod();
+    criteria.periodTypeCS = createConceptSetSelection(1,false);
+    
+    ObservationPeriodSqlBuilder<ObservationPeriod> builder = new ObservationPeriodSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("observationPeriod.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/observationPeriodConceptSet_VERIFY.json"};
     final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
 
     // Assert actual database table match expected table
@@ -639,6 +1059,90 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   }
 
   @Test
+  public void testProcedureOccurrenceConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/procedureOccurrenceConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    ProcedureOccurrence criteria = new ProcedureOccurrence();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.modifierCS = createConceptSetSelection(3,false);
+    criteria.procedureTypeCS = createConceptSetSelection(2,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+    
+    ProcedureOccurrenceSqlBuilder<ProcedureOccurrence> builder = new ProcedureOccurrenceSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("procedureOccurrence.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/procedureOccurrenceConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
+  public void testSpecimenConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/specimenConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    Specimen criteria = new Specimen();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.specimenTypeCS = createConceptSetSelection(2,false);
+    criteria.unitCS = createConceptSetSelection(3,false);
+    criteria.anatomicSiteCS = createConceptSetSelection(2,false);
+    criteria.diseaseStatusCS = createConceptSetSelection(3,false);
+    
+    SpecimenSqlBuilder<Specimen> builder = new SpecimenSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("specimen.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/specimenConceptSet_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
   public void testVisitOccurrenceDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
       "/datasets/vocabulary.json",
@@ -676,6 +1180,47 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Load expected data from an XML dataset
     final String[] testDataSetsVerify = new String[]{"/criteria/visitOccurrenceDateOffset_VERIFY.json"};
+    final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
+
+    // Assert actual database table match expected table
+    Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
+  public void testVisitOccurrenceConceptSet() throws Exception {
+    final String[] testDataSetsPrep = new String[]{
+      "/datasets/vocabulary.json",
+      "/criteria/codesets.json",
+      "/criteria/visitOccurrenceConceptSet_PREP.json"
+    };
+    final IDatabaseConnection dbUnitCon = getConnection();
+
+    // load test data into DB.
+    final IDataSet dsPrep = DataSetFactory.createDataSet(testDataSetsPrep);
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, dsPrep); // clean load of the DB. Careful, clean means "delete the old stuff"
+
+    // capture results in an ArrayList
+    ArrayList<ITable> actualTables = new ArrayList<>();
+
+    // Test 1: simple query with no special conditions
+    VisitOccurrence criteria = new VisitOccurrence();
+    criteria.codesetId = 1;
+    criteria.genderCS = createConceptSetSelection(1,false);
+    criteria.visitTypeCS = createConceptSetSelection(2,false);
+    criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
+    criteria.placeOfServiceCS = createConceptSetSelection(2,false);
+
+    VisitOccurrenceSqlBuilder<VisitOccurrence> builder = new VisitOccurrenceSqlBuilder<>();
+    String query = renderQuery(builder.getCriteriaSql(criteria));
+
+    // Store actual records from criteria query into actualTables
+    actualTables.add(new SortedTable(dbUnitCon.createQueryTable("visitOccurrence.conceptset", query), new String[]{"person_id", "start_date"}));
+
+    // Validate results:
+    final IDataSet actualDataSet = new CompositeDataSet(actualTables.toArray(new ITable[]{})); // put actual results into a CompositeDataSet
+
+    // Load expected data from an XML dataset
+    final String[] testDataSetsVerify = new String[]{"/criteria/visitOccurrenceConceptSet_VERIFY.json"};
     final IDataSet expectedDataSet = DataSetFactory.createDataSet(testDataSetsVerify);
 
     // Assert actual database table match expected table

--- a/src/test/java/org/ohdsi/circe/cohortdefinition/printfriendly/PrintFriendlyTest.java
+++ b/src/test/java/org/ohdsi/circe/cohortdefinition/printfriendly/PrintFriendlyTest.java
@@ -404,8 +404,6 @@ public class PrintFriendlyTest {
             "a visit type that is: \"admission note\" or \"ancillary report\";",
             //provider specialty
             "a provider specialty that is: \"general practice\" or \"general surgery\";",
-            // visit type
-            "a visit type that is: \"admission note\" or \"ancillary report\";",
             // visit length
             "with length &gt; 12 days",
             // nested criteria
@@ -421,8 +419,9 @@ public class PrintFriendlyTest {
             // concept set name and first in history attribute
             "1. visit detail of 'Concept Set 1' (including 'Concept Set 2' source concepts) for the first time in the person's history,",
             // age/gender criteria
-            "who are  between 18 and 64 years old, and who have gender concept in 'Concept Set 2' concept set;",
-            // start date/end date
+            "who are between 18 and 64 years old;",
+            "who have gender in 'Concept Set 2' concept set;",
+            //start date/end date
             "starting before January 1, 2010 and ending after January 7, 2010;",
             // visit type 
             "a visit detail type that is in 'Concept Set 2' concept set;",

--- a/src/test/resources/criteria/conditionEraConceptSet_PREP.json
+++ b/src/test/resources/criteria/conditionEraConceptSet_PREP.json
@@ -1,0 +1,71 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":2,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.condition_era": [
+    {
+      "condition_era_id": 1,
+      "person_id":1,
+      "condition_concept_id":1,
+      "condition_era_start_date":"2000-01-01",
+      "condition_era_end_date":"2000-01-01"
+    },
+    {
+      "condition_era_id": 2,
+      "person_id":1,
+      "condition_concept_id":1,
+      "condition_era_start_date":"2000-06-01",
+      "condition_era_end_date":"2000-07-01"
+    },
+    {
+      "condition_era_id": 3,
+      "person_id":1,
+      "condition_concept_id":1,
+      "condition_era_start_date":"2000-12-31",
+      "condition_era_end_date":"2000-12-31"
+    },
+    {
+      "condition_era_id": 4,
+      "person_id":2,
+      "condition_concept_id":1,
+      "condition_era_start_date":"2000-01-01",
+      "condition_era_end_date":"2000-01-01"
+    },
+    {
+      "condition_era_id": 5,
+      "person_id":2,
+      "condition_concept_id":1,
+      "condition_era_start_date":"2000-12-31",
+      "condition_era_end_date":"2000-12-31"
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ]
+}

--- a/src/test/resources/criteria/conditionEraConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/conditionEraConceptSet_VERIFY.json
@@ -1,0 +1,28 @@
+{
+	"conditionEra.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-01",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-01-01"
+		},
+		{
+			"person_id": 1,
+			"event_id": 2,
+			"start_date": "2000-06-01",
+			"end_date": "2000-07-01",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-06-01"
+		},
+    {
+			"person_id": 1,
+			"event_id": 3,
+			"start_date": "2000-12-31",
+			"end_date": "2000-12-31",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-12-31"
+		}
+	]
+}

--- a/src/test/resources/criteria/conditionOccurrenceConceptSet_PREP.json
+++ b/src/test/resources/criteria/conditionOccurrenceConceptSet_PREP.json
@@ -1,0 +1,91 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.condition_occurrence": [
+    {
+      "condition_occurrence_id": 1,
+      "person_id":1,
+      "condition_concept_id":1,
+      "condition_start_date":"2000-01-01",
+      "condition_type_concept_id":1,
+      "provider_id": 1,
+      "visit_occurrence_id": 1
+    },
+    {
+      "condition_occurrence_id": 2,
+      "person_id":1,
+      "condition_concept_id":1,
+      "condition_start_date":"2000-06-01",
+      "condition_end_date":"2000-07-01",
+      "condition_type_concept_id":2
+    },
+    {
+      "condition_occurrence_id": 3,
+      "person_id":1,
+      "condition_concept_id":1,
+      "condition_start_date":"2000-12-31",
+      "condition_type_concept_id":3
+    },
+    {
+      "condition_occurrence_id": 4,
+      "person_id":2,
+      "condition_concept_id":1,
+      "condition_start_date":"2000-01-01",
+      "condition_type_concept_id":0
+    },
+    {
+      "condition_occurrence_id": 5,
+      "person_id":2,
+      "condition_concept_id":1,
+      "condition_start_date":"2000-12-31",
+      "condition_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.visit_occurrence" : [
+    {
+      "visit_occurrence_id": 1,
+      "person_id": 1,
+      "visit_concept_id": 2,
+      "visit_start_date": "2000-01-01",
+      "visit_end_date": "2000-01-01",
+      "visit_type_concept_id": 4,
+      "provider_id":1
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ]
+}

--- a/src/test/resources/criteria/conditionOccurrenceConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/conditionOccurrenceConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"conditionOccurrence.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-02",
+			"visit_occurrence_id": 1,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/criteria/deathConceptSet_PREP.json
+++ b/src/test/resources/criteria/deathConceptSet_PREP.json
@@ -1,0 +1,48 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.death": [
+    {
+      "person_id":1,
+      "cause_concept_id":1,
+      "death_date":"2000-01-01",
+      "death_type_concept_id":1
+    },
+    {
+      "person_id":2,
+      "cause_concept_id":1,
+      "death_date":"2000-06-01",
+      "death_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ]
+}

--- a/src/test/resources/criteria/deathConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/deathConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"death.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-02",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/criteria/deviceExposureConceptSet_PREP.json
+++ b/src/test/resources/criteria/deviceExposureConceptSet_PREP.json
@@ -1,0 +1,91 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.device_exposure": [
+    {
+      "device_exposure_id": 1,
+      "person_id":1,
+      "device_concept_id":1,
+      "device_exposure_start_date":"2000-01-01",
+      "device_type_concept_id":1,
+      "provider_id": 1,
+      "visit_occurrence_id": 1
+    },
+    {
+      "device_exposure_id": 2,
+      "person_id":1,
+      "device_concept_id":1,
+      "device_exposure_start_date":"2000-06-01",
+      "device_exposure_end_date":"2000-07-01",
+      "device_type_concept_id":0
+    },
+    {
+      "device_exposure_id": 3,
+      "person_id":1,
+      "device_concept_id":1,
+      "device_exposure_start_date":"2000-12-31",
+      "device_type_concept_id":0
+    },
+    {
+      "device_exposure_id": 4,
+      "person_id":2,
+      "device_concept_id":1,
+      "device_exposure_start_date":"2000-01-01",
+      "device_type_concept_id":0
+    },
+    {
+      "device_exposure_id": 5,
+      "person_id":2,
+      "device_concept_id":1,
+      "device_exposure_start_date":"2000-12-31",
+      "device_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.visit_occurrence" : [
+    {
+      "visit_occurrence_id": 1,
+      "person_id": 1,
+      "visit_concept_id": 2,
+      "visit_start_date": "2000-01-01",
+      "visit_end_date": "2000-01-01",
+      "visit_type_concept_id": 4,
+      "provider_id":1
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ]
+}

--- a/src/test/resources/criteria/deviceExposureConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/deviceExposureConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"deviceExposure.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-02",
+			"visit_occurrence_id": 1,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/criteria/doseEraConceptSet_PREP.json
+++ b/src/test/resources/criteria/doseEraConceptSet_PREP.json
@@ -1,0 +1,81 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.dose_era": [
+    {
+      "dose_era_id": 1,
+      "person_id":1,
+      "drug_concept_id":1,
+      "unit_concept_id": 3,
+      "dose_value": 0.0,
+      "dose_era_start_date":"2000-01-01",
+      "dose_era_end_date":"2000-01-01"
+    },
+    {
+      "dose_era_id": 2,
+      "person_id":1,
+      "drug_concept_id":1,
+      "unit_concept_id": 0,
+      "dose_value": 0.0,
+      "dose_era_start_date":"2000-06-01",
+      "dose_era_end_date":"2000-07-01"
+    },
+    {
+      "dose_era_id": 3,
+      "person_id":1,
+      "drug_concept_id":1,
+      "unit_concept_id": 0,
+      "dose_value": 0.0,
+      "dose_era_start_date":"2000-12-31",
+      "dose_era_end_date":"2000-12-31"
+    },
+    {
+      "dose_era_id": 4,
+      "person_id":2,
+      "drug_concept_id":1,
+      "unit_concept_id": 0,
+      "dose_value": 0.0,
+      "dose_era_start_date":"2000-01-01",
+      "dose_era_end_date":"2000-01-01"
+    },
+    {
+      "dose_era_id": 5,
+      "person_id":2,
+      "drug_concept_id":1,
+      "unit_concept_id": 0,
+      "dose_value": 0.0,
+      "dose_era_start_date":"2000-12-31",
+      "dose_era_end_date":"2000-12-31"
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ]
+}

--- a/src/test/resources/criteria/doseEraConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/doseEraConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"doseEra.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-01",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/criteria/drugEraConceptSet_PREP.json
+++ b/src/test/resources/criteria/drugEraConceptSet_PREP.json
@@ -1,0 +1,71 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.drug_era": [
+    {
+      "drug_era_id": 1,
+      "person_id":1,
+      "drug_concept_id":1,
+      "drug_era_start_date":"2000-01-01",
+      "drug_era_end_date":"2000-01-01"
+    },
+    {
+      "drug_era_id": 2,
+      "person_id":1,
+      "drug_concept_id":1,
+      "drug_era_start_date":"2000-06-01",
+      "drug_era_end_date":"2000-07-01"
+    },
+    {
+      "drug_era_id": 3,
+      "person_id":1,
+      "drug_concept_id":1,
+      "drug_era_start_date":"2000-12-31",
+      "drug_era_end_date":"2000-12-31"
+    },
+    {
+      "drug_era_id": 4,
+      "person_id":2,
+      "drug_concept_id":1,
+      "drug_era_start_date":"2000-01-01",
+      "drug_era_end_date":"2000-01-01"
+    },
+    {
+      "drug_era_id": 5,
+      "person_id":2,
+      "drug_concept_id":1,
+      "drug_era_start_date":"2000-12-31",
+      "drug_era_end_date":"2000-12-31"
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ]
+}

--- a/src/test/resources/criteria/drugEraConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/drugEraConceptSet_VERIFY.json
@@ -1,0 +1,28 @@
+{
+	"drugEra.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-01",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-01-01"
+		},
+		{
+			"person_id": 1,
+			"event_id": 2,
+			"start_date": "2000-06-01",
+			"end_date": "2000-07-01",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-06-01"
+		},
+		{
+			"person_id": 1,
+			"event_id": 3,
+			"start_date": "2000-12-31",
+			"end_date": "2000-12-31",
+			"visit_occurrence_id": null,
+			"sort_date": "2000-12-31"
+		}
+	]
+}

--- a/src/test/resources/criteria/drugExposureConceptSet_PREP.json
+++ b/src/test/resources/criteria/drugExposureConceptSet_PREP.json
@@ -1,0 +1,93 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.drug_exposure": [
+    {
+      "drug_exposure_id": 1,
+      "person_id":1,
+      "drug_concept_id":1,
+      "drug_exposure_start_date":"2000-01-01",
+      "drug_type_concept_id":2,
+      "dose_unit_concept_id": 2,
+      "route_concept_id" : 3,
+      "provider_id": 1,
+      "visit_occurrence_id": 1
+    },
+    {
+      "drug_exposure_id": 2,
+      "person_id":1,
+      "drug_concept_id":1,
+      "drug_exposure_start_date":"2000-06-01",
+      "drug_exposure_end_date":"2000-07-01",
+      "drug_type_concept_id":0
+    },
+    {
+      "drug_exposure_id": 3,
+      "person_id":1,
+      "drug_concept_id":1,
+      "drug_exposure_start_date":"2000-12-31",
+      "drug_type_concept_id":0
+    },
+    {
+      "drug_exposure_id": 4,
+      "person_id":2,
+      "drug_concept_id":1,
+      "drug_exposure_start_date":"2000-01-01",
+      "drug_type_concept_id":0
+    },
+    {
+      "drug_exposure_id": 5,
+      "person_id":2,
+      "drug_concept_id":1,
+      "drug_exposure_start_date":"2000-12-31",
+      "drug_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.visit_occurrence" : [
+    {
+      "visit_occurrence_id": 1,
+      "person_id": 1,
+      "visit_concept_id": 2,
+      "visit_start_date": "2000-01-01",
+      "visit_end_date": "2000-01-01",
+      "visit_type_concept_id": 4,
+      "provider_id":1
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ]
+}

--- a/src/test/resources/criteria/drugExposureConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/drugExposureConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+  "drugExposure.conceptset": [
+    {
+      "person_id": 1,
+      "event_id": 1,
+      "start_date": "2000-01-01",
+      "end_date": "2000-01-02",
+      "visit_occurrence_id": 1,
+      "sort_date": "2000-01-01"
+    }
+  ]
+}

--- a/src/test/resources/criteria/measurementConceptSet_PREP.json
+++ b/src/test/resources/criteria/measurementConceptSet_PREP.json
@@ -1,0 +1,93 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.measurement": [
+    {
+      "measurement_id": 1,
+      "person_id":1,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":2,
+      "operator_concept_id": 3,
+      "value_as_concept_id": 2,
+      "unit_concept_id": 1,
+      "provider_id":1,
+      "visit_occurrence_id":1
+    },
+    {
+      "measurement_id": 2,
+      "person_id":1,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-06-01",
+      "measurement_type_concept_id":0
+    },
+    {
+      "measurement_id": 3,
+      "person_id":1,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-12-31",
+      "measurement_type_concept_id":0
+    },
+    {
+      "measurement_id": 4,
+      "person_id":2,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":0
+    },
+    {
+      "measurement_id": 5,
+      "person_id":2,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-12-31",
+      "measurement_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.visit_occurrence" : [
+    {
+      "visit_occurrence_id": 1,
+      "person_id": 1,
+      "visit_concept_id": 2,
+      "visit_start_date": "2000-01-01",
+      "visit_end_date": "2000-01-01",
+      "visit_type_concept_id": 4,
+      "provider_id":1
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ]
+}

--- a/src/test/resources/criteria/measurementConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/measurementConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"measurement.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-02",
+			"visit_occurrence_id": 1,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/criteria/observationConceptSet_PREP.json
+++ b/src/test/resources/criteria/observationConceptSet_PREP.json
@@ -1,0 +1,93 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.observation": [
+    {
+      "observation_id": 1,
+      "person_id":1,
+      "observation_concept_id":1,
+      "observation_date":"2000-01-01",
+      "observation_type_concept_id":1,
+      "qualifier_concept_id": 3,
+      "value_as_concept_id": 2,
+      "unit_concept_id": 1,
+      "provider_id":1,
+      "visit_occurrence_id":1
+    },
+    {
+      "observation_id": 2,
+      "person_id":1,
+      "observation_concept_id":1,
+      "observation_date":"2000-06-01",
+      "observation_type_concept_id":0
+    },
+    {
+      "observation_id": 3,
+      "person_id":1,
+      "observation_concept_id":1,
+      "observation_date":"2000-12-31",
+      "observation_type_concept_id":0
+    },
+    {
+      "observation_id": 4,
+      "person_id":2,
+      "observation_concept_id":1,
+      "observation_date":"2000-01-01",
+      "observation_type_concept_id":0
+    },
+    {
+      "observation_id": 5,
+      "person_id":2,
+      "observation_concept_id":1,
+      "observation_date":"2000-12-31",
+      "observation_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.visit_occurrence" : [
+    {
+      "visit_occurrence_id": 1,
+      "person_id": 1,
+      "visit_concept_id": 2,
+      "visit_start_date": "2000-01-01",
+      "visit_end_date": "2000-01-01",
+      "visit_type_concept_id": 4,
+      "provider_id":1
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ]
+}

--- a/src/test/resources/criteria/observationConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/observationConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"observation.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-02",
+			"visit_occurrence_id": 1,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/criteria/observationPeriodConceptSet_PREP.json
+++ b/src/test/resources/criteria/observationPeriodConceptSet_PREP.json
@@ -1,0 +1,48 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.observation_period": [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2000-05-31",
+      "period_type_concept_id": 1
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":1,
+      "observation_period_start_date":"2000-06-01",
+      "observation_period_end_date":"2000-06-10",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 3,
+      "person_id":1,
+      "observation_period_start_date":"2000-07-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 4,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-12-31",
+      "period_type_concept_id": 0
+    }
+  ]
+}

--- a/src/test/resources/criteria/observationPeriodConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/observationPeriodConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+  "observationPeriod.conceptset": [
+    {
+      "person_id": 1,
+      "event_id": 1,
+      "start_date": "2000-01-01",
+      "end_date": "2000-05-31",
+      "visit_occurrence_id": null,
+      "sort_date": "2000-01-01"
+    }
+  ]
+}

--- a/src/test/resources/criteria/procedureOccurrenceConceptSet_PREP.json
+++ b/src/test/resources/criteria/procedureOccurrenceConceptSet_PREP.json
@@ -1,0 +1,91 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.procedure_occurrence": [
+    {
+      "procedure_occurrence_id": 1,
+      "person_id":1,
+      "procedure_concept_id":1,
+      "procedure_date":"2000-01-01",
+      "procedure_type_concept_id":2,
+      "modifier_concept_id": 3,
+      "provider_id":1,
+      "visit_occurrence_id":1
+    },
+    {
+      "procedure_occurrence_id": 2,
+      "person_id":1,
+      "procedure_concept_id":1,
+      "procedure_date":"2000-06-01",
+      "procedure_type_concept_id":0
+    },
+    {
+      "procedure_occurrence_id": 3,
+      "person_id":1,
+      "procedure_concept_id":1,
+      "procedure_date":"2000-12-31",
+      "procedure_type_concept_id":0
+    },
+    {
+      "procedure_occurrence_id": 4,
+      "person_id":2,
+      "procedure_concept_id":1,
+      "procedure_date":"2000-01-01",
+      "procedure_type_concept_id":0
+    },
+    {
+      "procedure_occurrence_id": 5,
+      "person_id":2,
+      "procedure_concept_id":1,
+      "procedure_date":"2000-12-31",
+      "procedure_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.visit_occurrence" : [
+    {
+      "visit_occurrence_id": 1,
+      "person_id": 1,
+      "visit_concept_id": 2,
+      "visit_start_date": "2000-01-01",
+      "visit_end_date": "2000-01-01",
+      "visit_type_concept_id": 4,
+      "provider_id":1
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ]
+}

--- a/src/test/resources/criteria/procedureOccurrenceConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/procedureOccurrenceConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+  "procedureOccurrence.conceptset": [
+    {
+      "person_id": 1,
+      "event_id": 1,
+      "start_date": "2000-01-01",
+      "end_date": "2000-01-02",
+      "visit_occurrence_id": 1,
+      "sort_date": "2000-01-01"
+    }
+  ]
+}

--- a/src/test/resources/criteria/specimenConceptSet_PREP.json
+++ b/src/test/resources/criteria/specimenConceptSet_PREP.json
@@ -1,0 +1,74 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.specimen": [
+    {
+      "specimen_id": 1,
+      "person_id":1,
+      "specimen_concept_id":1,
+      "specimen_date":"2000-01-01",
+      "specimen_type_concept_id":2,
+      "unit_concept_id": 3,
+      "anatomic_site_concept_id":2,
+      "disease_status_concept_id":3
+    },
+    {
+      "specimen_id": 2,
+      "person_id":1,
+      "specimen_concept_id":1,
+      "specimen_date":"2000-06-01",
+      "specimen_type_concept_id":0
+    },
+    {
+      "specimen_id": 3,
+      "person_id":1,
+      "specimen_concept_id":1,
+      "specimen_date":"2000-12-31",
+      "specimen_type_concept_id":0
+    },
+    {
+      "specimen_id": 4,
+      "person_id":2,
+      "specimen_concept_id":1,
+      "specimen_date":"2000-01-01",
+      "specimen_type_concept_id":0
+    },
+    {
+      "specimen_id": 5,
+      "person_id":2,
+      "specimen_concept_id":1,
+      "specimen_date":"2000-12-31",
+      "specimen_type_concept_id":0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ]
+}

--- a/src/test/resources/criteria/specimenConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/specimenConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+  "specimen.conceptset": [
+    {
+      "person_id": 1,
+      "event_id": 1,
+      "start_date": "2000-01-01",
+      "end_date": "2000-01-02",
+      "visit_occurrence_id": null,
+      "sort_date": "2000-01-01"
+    }
+  ]
+}

--- a/src/test/resources/criteria/visitOccurrenceConceptSet_PREP.json
+++ b/src/test/resources/criteria/visitOccurrenceConceptSet_PREP.json
@@ -1,0 +1,90 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":1,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.visit_occurrence": [
+    {
+      "visit_occurrence_id": 1,
+      "person_id":1,
+      "visit_concept_id":1,
+      "visit_start_date":"2000-01-01",
+      "visit_end_date":"2000-01-01",
+      "visit_type_concept_id": 2,
+      "provider_id":1,
+      "care_site_id":1
+    },
+    {
+      "visit_occurrence_id": 2,
+      "person_id":1,
+      "visit_concept_id":1,
+      "visit_start_date":"2000-06-01",
+      "visit_end_date":"2000-07-01",
+      "visit_type_concept_id": 0
+    },
+    {
+      "visit_occurrence_id": 3,
+      "person_id":1,
+      "visit_concept_id":1,
+      "visit_start_date":"2000-12-31",
+      "visit_end_date":"2000-12-31",
+      "visit_type_concept_id": 0
+    },
+    {
+      "visit_occurrence_id": 4,
+      "person_id":2,
+      "visit_concept_id":1,
+      "visit_start_date":"2000-01-01",
+      "visit_end_date":"2000-01-01",
+      "visit_type_concept_id": 0
+    },
+    {
+      "visit_occurrence_id": 5,
+      "person_id":2,
+      "visit_concept_id":1,
+      "visit_start_date":"2000-12-31",
+      "visit_end_date":"2000-12-31",
+      "visit_type_concept_id": 0
+    }
+  ],
+  "cdm.observation_period" : [
+    {
+      "observation_period_id": 1,
+      "person_id":1,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    },
+    {
+      "observation_period_id": 2,
+      "person_id":2,
+      "observation_period_start_date":"2000-01-01",
+      "observation_period_end_date":"2001-01-01",
+      "period_type_concept_id": 0
+    }
+  ],
+  "cdm.provider" : [
+    {
+      "provider_id": 1,
+      "specialty_concept_id": 3
+    }
+  ],
+  "cdm.care_site": [
+    {
+      "care_site_id": 1,
+      "place_of_service_concept_id": 2
+    }
+  ]
+}

--- a/src/test/resources/criteria/visitOccurrenceConceptSet_VERIFY.json
+++ b/src/test/resources/criteria/visitOccurrenceConceptSet_VERIFY.json
@@ -1,0 +1,12 @@
+{
+	"visitOccurrence.conceptset": [
+		{
+			"person_id": 1,
+			"event_id": 1,
+			"start_date": "2000-01-01",
+			"end_date": "2000-01-01",
+			"visit_occurrence_id": 1,
+			"sort_date": "2000-01-01"
+		}
+	]
+}

--- a/src/test/resources/printfriendly/allAttributes.json
+++ b/src/test/resources/printfriendly/allAttributes.json
@@ -299,7 +299,22 @@
             "Value": "2010-01-01",
             "Op": "gte"
           },
-          "First": true
+          "First": true,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "ConditionTypeCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          },
+          "ConditionStatusCS" : {
+            "CodesetId": 0
+          }
         }
       },
       {
@@ -435,7 +450,10 @@
               "STANDARD_CONCEPT_CAPTION": "Unknown",
               "VOCABULARY_ID": "Gender"
             }
-          ]
+          ],
+          "GenderCS" : {
+            "CodesetId": 0
+          }
         }
       },
       {
@@ -517,7 +535,209 @@
               "STANDARD_CONCEPT_CAPTION": "Unknown",
               "VOCABULARY_ID": "Gender"
             }
-          ]
+          ],
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "DeathTypeCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "DeviceExposure" : {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "DeviceTypeCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "DoseEra" : {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "UnitCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "DrugEra" : {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "DrugExposure": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "DrugTypeCS" : {
+            "CodesetId": 0
+          },
+          "RouteConceptCS" : {
+            "CodesetId": 0
+          },
+          "DoseUnitCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          },
+          "ConditionStatusCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "Measurement": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "MeasurementTypeCS" : {
+            "CodesetId": 0
+          },
+          "OperatorCS" : {
+            "CodesetId": 0
+          },
+          "UnitCS" : {
+            "CodesetId": 0
+          },
+          "ValueAsConceptCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "Observation": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "ObservationTypeCS" : {
+            "CodesetId": 0
+          },
+          "QualifierCS" : {
+            "CodesetId": 0
+          },
+          "UnitCS" : {
+            "CodesetId": 0
+          },
+          "ValueAsConceptCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "ObservationPeriod": {
+          "CodesetId": 1,
+          "PeriodTypeCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "ProcedureOccurrence": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "ProcedureTypeCS" : {
+            "CodesetId": 0
+          },
+          "ModifierCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "Specimen": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "SpecimenTypeCS" : {
+            "CodesetId": 0
+          },
+          "UnitCS" : {
+            "CodesetId": 0
+          },
+          "AnatomicSiteCS" : {
+            "CodesetId": 0
+          },
+          "DiseaseStatusCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "VisitOccurrence": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "PlaceOfServiceCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "VisitDetail": {
+          "CodesetId": 1,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "VisitDetailTypeCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "PlaceOfServiceCS" : {
+            "CodesetId": 0
+          }
         }
       }
     ],

--- a/src/test/resources/printfriendly/allAttributes.json
+++ b/src/test/resources/printfriendly/allAttributes.json
@@ -294,31 +294,6 @@
       },
       {
         "ConditionOccurrence": {
-          "CodesetId": 1,
-          "OccurrenceStartDate": {
-            "Value": "2010-01-01",
-            "Op": "gte"
-          },
-          "First": true,
-          "GenderCS" : {
-            "CodesetId": 0
-          },
-          "ConditionTypeCS" : {
-            "CodesetId": 0
-          },
-          "ProviderSpecialtyCS" : {
-            "CodesetId": 0
-          },
-          "VisitTypeCS" : {
-            "CodesetId": 0
-          },
-          "ConditionStatusCS" : {
-            "CodesetId": 0
-          }
-        }
-      },
-      {
-        "ConditionOccurrence": {
           "CorrelatedCriteria": {
             "Type": "ALL",
             "CriteriaList": [
@@ -452,6 +427,31 @@
             }
           ],
           "GenderCS" : {
+            "CodesetId": 0
+          }
+        }
+      },
+      {
+        "ConditionOccurrence": {
+          "CodesetId": 1,
+          "OccurrenceStartDate": {
+            "Value": "2010-01-01",
+            "Op": "gte"
+          },
+          "First": true,
+          "GenderCS" : {
+            "CodesetId": 0
+          },
+          "ConditionTypeCS" : {
+            "CodesetId": 0
+          },
+          "ProviderSpecialtyCS" : {
+            "CodesetId": 0
+          },
+          "VisitTypeCS" : {
+            "CodesetId": 0
+          },
+          "ConditionStatusCS" : {
             "CodesetId": 0
           }
         }


### PR DESCRIPTION
This PR adds a concept set selection attribute along side any Concept[] attribute (gender, unit, value_as_concept, etc).
Updates PrintFriendly to render the new attributes.
Added tests to verify functionality.

Fixes Issue #215