### PR TITLE
Remove effective_drug_dose field from Circe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.ohdsi</groupId>
   <artifactId>circe</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.13.0-SNAPSHOT</version>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/DrugExposureSqlBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/DrugExposureSqlBuilder.java
@@ -107,11 +107,6 @@ public class DrugExposureSqlBuilder<T extends DrugExposure> extends CriteriaSqlB
       selectCols.add("de.route_concept_id");
     }
 
-    // effectiveDrugDose
-    if (criteria.effectiveDrugDose != null) {
-      selectCols.add("de.effective_drug_dose");
-    }
-
     // doseUnit
     if ((criteria.doseUnit != null && criteria.doseUnit.length > 0) ||
       criteria.doseUnitCS != null
@@ -224,11 +219,6 @@ public class DrugExposureSqlBuilder<T extends DrugExposure> extends CriteriaSqlB
     // routeConceptCS
     if (criteria.routeConceptCS != null) {
       whereClauses.add(getCodesetInExpression("C.route_concept_id", criteria.routeConceptCS));
-    }
-
-    // effectiveDrugDose
-    if (criteria.effectiveDrugDose != null) {
-      whereClauses.add(buildNumericRangeClause("C.effective_drug_dose", criteria.effectiveDrugDose, ".4f"));
     }
 
     // doseUnit


### PR DESCRIPTION
Following the discussion in [OHDSI/Atlas#2720](https://github.com/OHDSI/Atlas/issues/2720):

The effective_drug_dose field has been deprecated since OMOP CDM version 5.2.1 and is no longer part of the drug_exposure table. This PR removes the field from the cohort builder to align with the current CDM specification.