### PR TITLE
Fix value_as_concept_id missing from CTE when Measurement abnormal=true

### DIFF
--- a/src/main/java/org/ohdsi/circe/cohortdefinition/builders/MeasurementSqlBuilder.java
+++ b/src/main/java/org/ohdsi/circe/cohortdefinition/builders/MeasurementSqlBuilder.java
@@ -1,5 +1,6 @@
 package org.ohdsi.circe.cohortdefinition.builders;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.ohdsi.circe.cohortdefinition.Measurement;
 import org.ohdsi.circe.helper.ResourceHelper;
@@ -102,10 +103,8 @@ public class MeasurementSqlBuilder<T extends Measurement> extends CriteriaSqlBui
       selectCols.add("m.operator_concept_id");
     }
 
-    // valueAsConcept
-    if ((criteria.valueAsConcept != null && criteria.valueAsConcept.length > 0) ||
-      criteria.valueAsConceptCS != null
-    ) {
+    // valueAsConcept or abnormal
+    if (ArrayUtils.isNotEmpty(criteria.valueAsConcept) || criteria.valueAsConceptCS != null || Boolean.TRUE.equals(criteria.abnormal)) {
       selectCols.add("m.value_as_concept_id");
     }
 
@@ -140,7 +139,7 @@ public class MeasurementSqlBuilder<T extends Measurement> extends CriteriaSqlBui
     List<String> joinClauses = new ArrayList<>();
 
     // join to PERSON
-    if (criteria.age != null || 
+    if (criteria.age != null ||
       (criteria.gender != null && criteria.gender.length > 0) ||
       criteria.genderCS != null
     ) {
@@ -207,7 +206,7 @@ public class MeasurementSqlBuilder<T extends Measurement> extends CriteriaSqlBui
     if (criteria.valueAsConceptCS != null) {
       whereClauses.add(getCodesetInExpression("C.value_as_concept_id", criteria.valueAsConceptCS));
     }
-    
+
     // unit
     if (criteria.unit != null && criteria.unit.length > 0) {
       ArrayList<Long> conceptIds = getConceptIdsFromConcepts(criteria.unit);
@@ -218,7 +217,7 @@ public class MeasurementSqlBuilder<T extends Measurement> extends CriteriaSqlBui
     if (criteria.unitCS != null) {
       whereClauses.add(getCodesetInExpression("C.unit_concept_id", criteria.unitCS));
     }
-    
+
     // rangeLow
     if (criteria.rangeLow != null) {
       whereClauses.add(buildNumericRangeClause("C.range_low", criteria.rangeLow, ".4f"));

--- a/src/test/java/org/ohdsi/circe/cohortdefinition/builders/CriteriaQuery_5_0_0_Test.java
+++ b/src/test/java/org/ohdsi/circe/cohortdefinition/builders/CriteriaQuery_5_0_0_Test.java
@@ -27,6 +27,8 @@ import org.dbunit.dataset.SortedTable;
 import org.dbunit.operation.DatabaseOperation;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import org.ohdsi.circe.AbstractDatabaseTest;
 import org.ohdsi.circe.cohortdefinition.ConceptSetSelection;
 import org.ohdsi.circe.cohortdefinition.ConditionEra;
@@ -64,7 +66,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
   private static final ConceptSetSelection CONCEPTSET_2 = null;
   private static final ConceptSetSelection CONCEPTSET_3 = null;
   private static final ConceptSetSelection CONCEPTSET_4 = null;
-  
+
 
   private String renderQuery(String query) {
     String result = StringUtils.replace(query, "#Codesets", "temp.codesets");
@@ -91,7 +93,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     prepareSchema("cdm", CDM_DDL_PATH);
     prepareSchema("temp", TEMP_DDL_PATH);
   }
-  
+
   private ConceptSetSelection createConceptSetSelection(Integer id, boolean isExcluded) {
     ConceptSetSelection css = new ConceptSetSelection();
     css.codesetId = id;
@@ -147,7 +149,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     // Assert actual database table match expected table
     Assertion.assertEquals(expectedDataSet, actualDataSet);
   }
-  
+
   @Test
   public void testConditionEraConceptSet() throws Exception {
     final String[] testDataSetsPrep = new String[]{
@@ -252,7 +254,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     criteria.genderCS = createConceptSetSelection(1,false);
     criteria.visitTypeCS = createConceptSetSelection(2,false);
     criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
-    
+
 
     ConditionOccurrenceSqlBuilder<ConditionOccurrence> builder = new ConditionOccurrenceSqlBuilder<>();
     String query = renderQuery(builder.getCriteriaSql(criteria));
@@ -270,7 +272,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     // Assert actual database table match expected table
     Assertion.assertEquals(expectedDataSet, actualDataSet);
   }
-  
+
   @Test
   public void testDeathDateOffset() throws Exception {
     final String[] testDataSetsPrep = new String[]{
@@ -315,7 +317,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     Assertion.assertEquals(expectedDataSet, actualDataSet);
   }
 
-  
+
   @Test
   public void testDeathConceptSet() throws Exception {
     final String[] testDataSetsPrep = new String[]{
@@ -505,7 +507,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     criteria.codesetId = 1;
     criteria.genderCS = createConceptSetSelection(1,false);
     criteria.unitCS = createConceptSetSelection(3,false);
-    
+
 
     DoseEraSqlBuilder<DoseEra> builder = new DoseEraSqlBuilder<>();
     String query = renderQuery(builder.getCriteriaSql(criteria));
@@ -522,7 +524,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Assert actual database table match expected table
     Assertion.assertEquals(expectedDataSet, actualDataSet);
-  }  
+  }
 
   @Test
   public void testDrugEraDateOffset() throws Exception {
@@ -691,7 +693,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Assert actual database table match expected table
     Assertion.assertEquals(expectedDataSet, actualDataSet);
-  }  
+  }
 
   @Test
   public void testMeasurementDateOffset() throws Exception {
@@ -763,7 +765,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     criteria.genderCS = createConceptSetSelection(1,false);
     criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
     criteria.visitTypeCS = createConceptSetSelection(2,false);
-    
+
     MeasurementSqlBuilder<Measurement> builder = new MeasurementSqlBuilder<>();
     String query = renderQuery(builder.getCriteriaSql(criteria));
 
@@ -942,7 +944,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     // Test 1: simple query with no special conditions
     ObservationPeriod criteria = new ObservationPeriod();
     criteria.periodTypeCS = createConceptSetSelection(1,false);
-    
+
     ObservationPeriodSqlBuilder<ObservationPeriod> builder = new ObservationPeriodSqlBuilder<>();
     String query = renderQuery(builder.getCriteriaSql(criteria));
 
@@ -1082,7 +1084,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     criteria.procedureTypeCS = createConceptSetSelection(2,false);
     criteria.visitTypeCS = createConceptSetSelection(2,false);
     criteria.providerSpecialtyCS = createConceptSetSelection(3,false);
-    
+
     ProcedureOccurrenceSqlBuilder<ProcedureOccurrence> builder = new ProcedureOccurrenceSqlBuilder<>();
     String query = renderQuery(builder.getCriteriaSql(criteria));
 
@@ -1124,7 +1126,7 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
     criteria.unitCS = createConceptSetSelection(3,false);
     criteria.anatomicSiteCS = createConceptSetSelection(2,false);
     criteria.diseaseStatusCS = createConceptSetSelection(3,false);
-    
+
     SpecimenSqlBuilder<Specimen> builder = new SpecimenSqlBuilder<>();
     String query = renderQuery(builder.getCriteriaSql(criteria));
 
@@ -1225,5 +1227,30 @@ public class CriteriaQuery_5_0_0_Test extends AbstractDatabaseTest {
 
     // Assert actual database table match expected table
     Assertion.assertEquals(expectedDataSet, actualDataSet);
+  }
+
+  @Test
+  public void testMeasurementAbnormal() throws Exception {
+    final IDatabaseConnection dbUnitCon = getConnection();
+    DatabaseOperation.CLEAN_INSERT.execute(dbUnitCon, DataSetFactory.createDataSet(new String[]{ "/datasets/vocabulary.json", "/criteria/codesets.json", "/criteria/measurementAbnormal_PREP.json"}));
+
+    Measurement criteria = new Measurement();
+    criteria.codesetId = 1;
+    criteria.abnormal = true;
+
+    String query = renderQuery(new MeasurementSqlBuilder<>().getCriteriaSql(criteria));
+
+    assertThat(query, containsString("m.value_as_concept_id"));
+    assertThat(query, containsString("C.value_as_number < C.range_low"));
+    assertThat(query, containsString("C.value_as_number > C.range_high"));
+    assertThat(query, containsString("C.value_as_concept_id in (4155142, 4155143)"));
+
+    // Verify the query executes without error and returns only abnormal measurements
+    ITable actual = new SortedTable(
+      dbUnitCon.createQueryTable("measurement.abnormal", query),
+      new String[]{"person_id", "start_date"}
+    );
+    IDataSet expected = DataSetFactory.createDataSet(new String[]{"/criteria/measurementAbnormal_VERIFY.json"});
+    Assertion.assertEquals(expected, new CompositeDataSet(new ITable[]{actual}));
   }
 }

--- a/src/test/resources/criteria/measurementAbnormal_PREP.json
+++ b/src/test/resources/criteria/measurementAbnormal_PREP.json
@@ -1,0 +1,86 @@
+{
+  "cdm.person": [
+    {
+      "person_id":1,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":2,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":3,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":4,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    },
+    {
+      "person_id":5,
+      "gender_concept_id":0,
+      "year_of_birth":0,
+      "race_concept_id":0,
+      "ethnicity_concept_id":0
+    }
+  ],
+  "cdm.measurement": [
+    {
+      "measurement_id": 1,
+      "person_id":1,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":0,
+      "value_as_number":5,
+      "range_low":10,
+      "range_high":20
+    },
+    {
+      "measurement_id": 2,
+      "person_id":2,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":0,
+      "value_as_concept_id":4155142
+    },
+    {
+      "measurement_id": 3,
+      "person_id":3,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":0,
+      "value_as_number":15,
+      "range_low":10,
+      "range_high":20
+    },
+    {
+      "measurement_id": 4,
+      "person_id":4,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":0
+    },
+    {
+      "measurement_id": 5,
+      "person_id":5,
+      "measurement_concept_id":1,
+      "measurement_date":"2000-01-01",
+      "measurement_type_concept_id":0,
+      "value_as_number":25,
+      "range_low":10,
+      "range_high":20
+    }
+  ]
+}

--- a/src/test/resources/criteria/measurementAbnormal_VERIFY.json
+++ b/src/test/resources/criteria/measurementAbnormal_VERIFY.json
@@ -1,0 +1,28 @@
+{
+  "measurement.abnormal": [
+    {
+      "person_id": 1,
+      "event_id": 1,
+      "start_date": "2000-01-01",
+      "end_date": "2000-01-02",
+      "visit_occurrence_id": null,
+      "sort_date": "2000-01-01"
+    },
+    {
+      "person_id": 2,
+      "event_id": 2,
+      "start_date": "2000-01-01",
+      "end_date": "2000-01-02",
+      "visit_occurrence_id": null,
+      "sort_date": "2000-01-01"
+    },
+    {
+      "person_id": 5,
+      "event_id": 5,
+      "start_date": "2000-01-01",
+      "end_date": "2000-01-02",
+      "visit_occurrence_id": null,
+      "sort_date": "2000-01-01"
+    }
+  ]
+}


### PR DESCRIPTION
### Bug

When `abnormal=true` is set without explicit concept values, the generated SQL fails with `column c.value_as_concept_id does not exist`. The column was only added to the CTE `SELECT` when `valueAsConcept` or `valueAsConceptCS` was set, but the abnormal `WHERE` clause always references it.



### Before
```sql
select
  m.person_id, m.measurement_id, m.measurement_concept_id,
  m.visit_occurrence_id, m.value_as_number,
  m.range_high, m.range_low,
  -- ❌ value_as_concept_id missing
  m.measurement_date as start_date, ...
WHERE (C.value_as_number < C.range_low or C.value_as_number > C.range_high
  or C.value_as_concept_id in (4155142, 4155143))  -- ❌ column doesn't exist
```

### After
```sql
select
  m.person_id, m.measurement_id, m.measurement_concept_id,
  m.visit_occurrence_id, m.value_as_number,
  m.range_high, m.range_low, m.value_as_concept_id,  -- ✅ now included
  m.measurement_date as start_date, ...
WHERE (C.value_as_number < C.range_low or C.value_as_number > C.range_high
  or C.value_as_concept_id in (4155142, 4155143))  -- ✅ works
```